### PR TITLE
feat: Add `isNetworkPassphrase` method to `AnchorConfig` for comparg passphrases against configured or default network values, along with corresponding tests.

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -50,6 +50,40 @@ export class AnchorConfig {
   }
 
   /**
+   * Compare a provided passphrase against the configured network passphrase.
+   * Uses network default passphrases if an explicit one is not configured.
+   *
+   * @param passphrase - The passphrase to check.
+   * @returns boolean - True if it matches, false otherwise.
+   */
+  public isNetworkPassphrase(passphrase: string): boolean {
+    const configuredPassphrase = this.config.network?.networkPassphrase;
+
+    if (configuredPassphrase) {
+      return passphrase === configuredPassphrase;
+    }
+
+    const network = this.config.network?.network;
+    let defaultPassphrase: string;
+
+    switch (network) {
+      case 'public':
+        defaultPassphrase = 'Public Global Stellar Network ; September 2015';
+        break;
+      case 'testnet':
+        defaultPassphrase = 'Test SDF Network ; September 2015';
+        break;
+      case 'futurenet':
+        defaultPassphrase = 'Test SDF Future Network ; Fall 2022';
+        break;
+      default:
+        return false;
+    }
+
+    return passphrase === defaultPassphrase;
+  }
+
+  /**
    * Validate the configuration object for required secrets,
    * URLs, network values, and basic structural invariants.
    * Throws ConfigurationError if validation fails.

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -91,6 +91,49 @@ describe('AnchorConfig', () => {
     });
   });
 
+  describe('isNetworkPassphrase()', () => {
+    it('should return true for configured network passphrase', () => {
+      const configWithPassphrase: AnchorKitConfig = {
+        ...validBaseConfig,
+        network: {
+          ...validBaseConfig.network,
+          networkPassphrase: 'Custom Network Passphrase',
+        },
+      };
+      const config = new AnchorConfig(configWithPassphrase);
+      expect(config.isNetworkPassphrase('Custom Network Passphrase')).toBe(true);
+      expect(config.isNetworkPassphrase('Test SDF Network ; September 2015')).toBe(false);
+    });
+
+    it('should fall back to testnet default passphrase', () => {
+      const config = new AnchorConfig(validBaseConfig); // validBaseConfig has network: 'testnet'
+      expect(config.isNetworkPassphrase('Test SDF Network ; September 2015')).toBe(true);
+      expect(config.isNetworkPassphrase('Wrong Passphrase')).toBe(false);
+    });
+
+    it('should fall back to public default passphrase', () => {
+      const configPublic: AnchorKitConfig = {
+        ...validBaseConfig,
+        network: { network: 'public' },
+      };
+      const config = new AnchorConfig(configPublic);
+      expect(config.isNetworkPassphrase('Public Global Stellar Network ; September 2015')).toBe(
+        true,
+      );
+      expect(config.isNetworkPassphrase('Test SDF Network ; September 2015')).toBe(false);
+    });
+
+    it('should fall back to futurenet default passphrase', () => {
+      const configFuturenet: AnchorKitConfig = {
+        ...validBaseConfig,
+        network: { network: 'futurenet' },
+      };
+      const config = new AnchorConfig(configFuturenet);
+      expect(config.isNetworkPassphrase('Test SDF Future Network ; Fall 2022')).toBe(true);
+      expect(config.isNetworkPassphrase('Test SDF Network ; September 2015')).toBe(false);
+    });
+  });
+
   describe('validate()', () => {
     it('should pass for a valid configuration', () => {
       const config = new AnchorConfig(validBaseConfig);


### PR DESCRIPTION

## What does this PR do?

Implmented `isNetworkPassphrase` method: Added the logic in `src/core/config.ts` to first check the passphrase against this.config.network.networkPassphrase. If it's undefined, it falls back to the default network passphrase based on the configured network (public, testnet, or futurenet).

## How to test?
`bun run test`

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #29
