### PR TITLE
fix: export makeSqliteDbUrlForTests from package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ The SDK does not own `listen()` and does not bind network ports.
 bun add anchor-kit
 ```
 
-For tests and local development, you can import `makeSqliteDbUrlForTests` directly from `anchor-kit`.
-
 ## Quick Start
 
 ```ts
@@ -95,6 +93,16 @@ await anchor.startBackgroundJobs();
 app.use('/anchor', anchor.getExpressRouter());
 
 app.listen(3000);
+```
+
+## Testing
+
+For tests and local development, `makeSqliteDbUrlForTests` creates a temporary SQLite database URL that you can import directly from `anchor-kit`.
+
+```ts
+import { makeSqliteDbUrlForTests } from 'anchor-kit';
+
+const databaseUrl = makeSqliteDbUrlForTests();
 ```
 
 ## Endpoints

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The SDK does not own `listen()` and does not bind network ports.
 bun add anchor-kit
 ```
 
+For tests and local development, you can import `makeSqliteDbUrlForTests` directly from `anchor-kit`.
+
 ## Quick Start
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 export * from './types';
-export { AnchorInstance, createAnchor } from './core/factory';
+export { AnchorInstance, createAnchor, makeSqliteDbUrlForTests } from './core/factory';
 export * from './core/errors';
 export * as utils from './utils';
 export { AssetSchema, DatabaseUrlSchema } from './utils';

--- a/tests/verify-exports.test.ts
+++ b/tests/verify-exports.test.ts
@@ -1,4 +1,4 @@
-import { AssetSchema, DatabaseUrlSchema, utils } from '../src/index';
+import { AssetSchema, DatabaseUrlSchema, makeSqliteDbUrlForTests, utils } from '../src/index';
 import { describe, expect, it } from 'vitest';
 
 describe('Export Verification', () => {
@@ -15,6 +15,12 @@ describe('Export Verification', () => {
   it('should still be available through utils.AssetSchema', () => {
     expect(utils.AssetSchema).toBeDefined();
     expect(utils.AssetSchema).toBe(AssetSchema);
+  });
+
+  it('should export makeSqliteDbUrlForTests at the top level', () => {
+    expect(makeSqliteDbUrlForTests).toBeDefined();
+    expect(typeof makeSqliteDbUrlForTests).toBe('function');
+    expect(makeSqliteDbUrlForTests()).toMatch(/^file:/);
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Exports `makeSqliteDbUrlForTests` from the package root by re-exporting the existing helper through the public `src/index.ts` barrel. Also updates the export verification test to prove the helper is available from the root entry point, and adds a short README note documenting the public import.

## How to test?

Run:

```bash
bun test tests/verify-exports.test.ts
bun test
bun run lint
```

Verify that `makeSqliteDbUrlForTests` can be imported directly from `anchor-kit`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #136
