### PR TITLE
fix: export TransactionKind as a public type alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Mounted under your chosen base path (for example `/anchor`):
 - [Contributing Guide](./CONTRIBUTING.md)
 - [Roadmap](./ROADMAP.md)
 
+The root package also exports public TypeScript transaction helpers, including `Transaction`, `TransactionKind`, and `TransactionStatus`.
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](./CONTRIBUTING.md) for details on how to get started.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ export type { Customer } from './customer.ts';
 
 export type {
   Transaction,
+  TransactionKind,
   Amount,
   RailTransactionData,
   StellarTransactionData,

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -8,6 +8,8 @@
 
 import type { TransactionStatus } from './transaction-status.ts';
 
+export type TransactionKind = 'deposit' | 'withdrawal';
+
 /**
  * Represents a monetary amount with currency/asset information
  * Uses string for decimal precision (common pattern for financial data)
@@ -140,7 +142,7 @@ export interface Transaction {
   status: TransactionStatus;
 
   /** Transaction type: 'deposit' (fiat->crypto) or 'withdrawal' (crypto->fiat) */
-  kind: 'deposit' | 'withdrawal';
+  kind: TransactionKind;
 
   // ============================================
   // Amount Fields (using Decimal string representation)

--- a/tests/types/transaction.test.ts
+++ b/tests/types/transaction.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import type {
   Transaction,
   TransactionKind,

--- a/tests/types/transaction.test.ts
+++ b/tests/types/transaction.test.ts
@@ -1,5 +1,6 @@
 import type {
   Transaction,
+  TransactionKind,
   Amount,
   RailTransactionData,
   StellarTransactionData,
@@ -14,6 +15,15 @@ describe('Transaction', () => {
   // ============================================
 
   describe('core fields', () => {
+    it('exports TransactionKind as the Transaction kind alias', () => {
+      const deposit: TransactionKind = 'deposit';
+      const withdrawal: TransactionKind = 'withdrawal';
+
+      expect(deposit).toBe('deposit');
+      expect(withdrawal).toBe('withdrawal');
+      expectTypeOf<Transaction['kind']>().toEqualTypeOf<TransactionKind>();
+    });
+
     it('requires id, status, and kind', () => {
       const tx: Transaction = {
         id: 'txn-001',

--- a/tests/verify-exports.test.ts
+++ b/tests/verify-exports.test.ts
@@ -1,7 +1,16 @@
 import { AssetSchema, DatabaseUrlSchema, makeSqliteDbUrlForTests, utils } from '../src/index';
+import type { TransactionKind } from '../src/index';
 import { describe, expect, it } from 'vitest';
 
 describe('Export Verification', () => {
+  it('should export TransactionKind at the top level', () => {
+    const deposit: TransactionKind = 'deposit';
+    const withdrawal: TransactionKind = 'withdrawal';
+
+    expect(deposit).toBe('deposit');
+    expect(withdrawal).toBe('withdrawal');
+  });
+
   it('should export AssetSchema at the top level', () => {
     expect(AssetSchema).toBeDefined();
     expect(typeof AssetSchema.isValid).toBe('function');


### PR DESCRIPTION
## What does this PR do?

Exports `TransactionKind` as a public type alias for `'deposit' | 'withdrawal'`, updates the public `Transaction` typing to use that alias, and adds focused test coverage to verify both barrel-level compatibility and root-package export availability.

## How to test?

Run:

```bash
bun run test
bun run lint
bun run build
```

Focused verification for this issue is covered by:

```bash
bun test tests/types/transaction.test.ts tests/verify-exports.test.ts
```

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #133
