### PR TITLE
fix: add isPendingTransactionStatus helper

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,11 @@
  * This is the main entry point for all type exports
  */
 
-export { TRANSACTION_STATUSES, isTerminalTransactionStatus } from './transaction-status.ts';
+export {
+  TRANSACTION_STATUSES,
+  isPendingTransactionStatus,
+  isTerminalTransactionStatus,
+} from './transaction-status.ts';
 export type { TerminalTransactionStatus, TransactionStatus } from './transaction-status.ts';
 
 export type { Customer } from './customer.ts';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,11 @@ export {
   isPendingTransactionStatus,
   isTerminalTransactionStatus,
 } from './transaction-status.ts';
-export type { TerminalTransactionStatus, TransactionStatus } from './transaction-status.ts';
+export type {
+  PendingTransactionStatus,
+  TerminalTransactionStatus,
+  TransactionStatus,
+} from './transaction-status.ts';
 
 export type { Customer } from './customer.ts';
 

--- a/src/types/transaction-status.ts
+++ b/src/types/transaction-status.ts
@@ -52,6 +52,9 @@ export function isTerminalTransactionStatus(
   return (TERMINAL_TRANSACTION_STATUSES as readonly TransactionStatus[]).includes(status);
 }
 
+/** Union of all pending transaction statuses. */
+export type PendingTransactionStatus = Extract<TransactionStatus, `pending_${string}`>;
+
 const PENDING_TRANSACTION_STATUSES: ReadonlySet<TransactionStatus> = new Set([
   'pending_anchor',
   'pending_user_transfer_start',
@@ -74,6 +77,8 @@ const PENDING_TRANSACTION_STATUSES: ReadonlySet<TransactionStatus> = new Set([
  * - `pending_user`
  * - `pending_stellar`
  */
-export function isPendingTransactionStatus(status: TransactionStatus): boolean {
+export function isPendingTransactionStatus(
+  status: TransactionStatus,
+): status is PendingTransactionStatus {
   return PENDING_TRANSACTION_STATUSES.has(status);
 }

--- a/src/types/transaction-status.ts
+++ b/src/types/transaction-status.ts
@@ -51,3 +51,29 @@ export function isTerminalTransactionStatus(
 ): status is TerminalTransactionStatus {
   return (TERMINAL_TRANSACTION_STATUSES as readonly TransactionStatus[]).includes(status);
 }
+
+const PENDING_TRANSACTION_STATUSES: ReadonlySet<TransactionStatus> = new Set([
+  'pending_anchor',
+  'pending_user_transfer_start',
+  'pending_user_transfer_complete',
+  'pending_external',
+  'pending_trust',
+  'pending_user',
+  'pending_stellar',
+]);
+
+/**
+ * Returns whether a transaction is still in progress.
+ *
+ * Pending statuses are:
+ * - `pending_anchor`
+ * - `pending_user_transfer_start`
+ * - `pending_user_transfer_complete`
+ * - `pending_external`
+ * - `pending_trust`
+ * - `pending_user`
+ * - `pending_stellar`
+ */
+export function isPendingTransactionStatus(status: TransactionStatus): boolean {
+  return PENDING_TRANSACTION_STATUSES.has(status);
+}

--- a/tests/types/transaction-status.test.ts
+++ b/tests/types/transaction-status.test.ts
@@ -1,4 +1,5 @@
 import {
+  isPendingTransactionStatus,
   isTerminalTransactionStatus,
   TRANSACTION_STATUSES,
   type TerminalTransactionStatus,
@@ -65,6 +66,35 @@ describe('TransactionStatus', () => {
       'too_small',
       'too_large',
     ] satisfies TerminalTransactionStatus[]);
+  });
+
+  it('returns true for every pending or in-progress status', () => {
+    const pendingStatuses: TransactionStatus[] = [
+      'pending_anchor',
+      'pending_user_transfer_start',
+      'pending_user_transfer_complete',
+      'pending_external',
+      'pending_trust',
+      'pending_user',
+      'pending_stellar',
+    ];
+
+    expect(pendingStatuses.every((status) => isPendingTransactionStatus(status))).toBe(true);
+  });
+
+  it('returns false for every non-pending status', () => {
+    const nonPendingStatuses: TransactionStatus[] = [
+      'incomplete',
+      'completed',
+      'refunded',
+      'expired',
+      'error',
+      'no_market',
+      'too_small',
+      'too_large',
+    ];
+
+    expect(nonPendingStatuses.every((status) => !isPendingTransactionStatus(status))).toBe(true);
   });
 
   // -- compile-time checks (tsc catches these before tests even run) --

--- a/tests/types/transaction-status.test.ts
+++ b/tests/types/transaction-status.test.ts
@@ -2,6 +2,7 @@ import {
   isPendingTransactionStatus,
   isTerminalTransactionStatus,
   TRANSACTION_STATUSES,
+  type PendingTransactionStatus,
   type TerminalTransactionStatus,
   type TransactionStatus,
 } from '@/types/index.ts';
@@ -95,6 +96,18 @@ describe('TransactionStatus', () => {
     ];
 
     expect(nonPendingStatuses.every((status) => !isPendingTransactionStatus(status))).toBe(true);
+  });
+
+  it('narrows to PendingTransactionStatus when the helper returns true', () => {
+    const status: TransactionStatus = 'pending_anchor';
+
+    if (isPendingTransactionStatus(status)) {
+      const narrowed: PendingTransactionStatus = status;
+      expect(narrowed).toBe('pending_anchor');
+      return;
+    }
+
+    throw new Error('expected status to narrow to PendingTransactionStatus');
   });
 
   // -- compile-time checks (tsc catches these before tests even run) --


### PR DESCRIPTION
## What does this PR do?

Adds a public `isPendingTransactionStatus(status: TransactionStatus): boolean` helper for SEP-24 transaction statuses.

The helper is exported from the public types surface and documents the exact statuses it treats as pending or in-progress:
- `pending_anchor`
- `pending_user_transfer_start`
- `pending_user_transfer_complete`
- `pending_external`
- `pending_trust`
- `pending_user`
- `pending_stellar`

## How to test?

```bash
bun install --frozen-lockfile
bun run lint
bun test
```

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #132
