### PR TITLE
feat: add isTerminalTransactionStatus helper

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@
  * This is the main entry point for all type exports
  */
 
-export { TRANSACTION_STATUSES } from './transaction-status.ts';
+export { TRANSACTION_STATUSES, isTerminalTransactionStatus } from './transaction-status.ts';
 export type { TransactionStatus } from './transaction-status.ts';
 
 export type { Customer } from './customer.ts';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@
  */
 
 export { TRANSACTION_STATUSES, isTerminalTransactionStatus } from './transaction-status.ts';
-export type { TransactionStatus } from './transaction-status.ts';
+export type { TerminalTransactionStatus, TransactionStatus } from './transaction-status.ts';
 
 export type { Customer } from './customer.ts';
 

--- a/src/types/transaction-status.ts
+++ b/src/types/transaction-status.ts
@@ -27,7 +27,7 @@ export const TRANSACTION_STATUSES = [
 /** Union of all valid transaction statuses, pulled from the array above. */
 export type TransactionStatus = (typeof TRANSACTION_STATUSES)[number];
 
-const TERMINAL_TRANSACTION_STATUSES: readonly TransactionStatus[] = [
+const TERMINAL_TRANSACTION_STATUSES = [
   'completed',
   'refunded',
   'expired',
@@ -35,7 +35,10 @@ const TERMINAL_TRANSACTION_STATUSES: readonly TransactionStatus[] = [
   'no_market',
   'too_small',
   'too_large',
-];
+] as const;
+
+/** Union of transaction statuses that cannot make further progress. */
+export type TerminalTransactionStatus = (typeof TERMINAL_TRANSACTION_STATUSES)[number];
 
 /**
  * Returns true when a transaction can no longer make progress.
@@ -43,6 +46,8 @@ const TERMINAL_TRANSACTION_STATUSES: readonly TransactionStatus[] = [
  * Terminal statuses:
  * `completed`, `refunded`, `expired`, `error`, `no_market`, `too_small`, `too_large`
  */
-export function isTerminalTransactionStatus(status: TransactionStatus): boolean {
-  return TERMINAL_TRANSACTION_STATUSES.includes(status);
+export function isTerminalTransactionStatus(
+  status: TransactionStatus,
+): status is TerminalTransactionStatus {
+  return (TERMINAL_TRANSACTION_STATUSES as readonly TransactionStatus[]).includes(status);
 }

--- a/src/types/transaction-status.ts
+++ b/src/types/transaction-status.ts
@@ -26,3 +26,23 @@ export const TRANSACTION_STATUSES = [
 
 /** Union of all valid transaction statuses, pulled from the array above. */
 export type TransactionStatus = (typeof TRANSACTION_STATUSES)[number];
+
+const TERMINAL_TRANSACTION_STATUSES: readonly TransactionStatus[] = [
+  'completed',
+  'refunded',
+  'expired',
+  'error',
+  'no_market',
+  'too_small',
+  'too_large',
+];
+
+/**
+ * Returns true when a transaction can no longer make progress.
+ *
+ * Terminal statuses:
+ * `completed`, `refunded`, `expired`, `error`, `no_market`, `too_small`, `too_large`
+ */
+export function isTerminalTransactionStatus(status: TransactionStatus): boolean {
+  return TERMINAL_TRANSACTION_STATUSES.includes(status);
+}

--- a/tests/types/transaction-status.test.ts
+++ b/tests/types/transaction-status.test.ts
@@ -36,7 +36,7 @@ describe('TransactionStatus', () => {
   });
 
   it('returns the expected result for every valid status', () => {
-    const terminalStatuses = new Set<TerminalTransactionStatus>([
+    const terminalStatuses = new Set<TransactionStatus>([
       'completed',
       'refunded',
       'expired',

--- a/tests/types/transaction-status.test.ts
+++ b/tests/types/transaction-status.test.ts
@@ -1,6 +1,7 @@
 import {
   isTerminalTransactionStatus,
   TRANSACTION_STATUSES,
+  type TerminalTransactionStatus,
   type TransactionStatus,
 } from '@/types/index.ts';
 
@@ -34,8 +35,8 @@ describe('TransactionStatus', () => {
     expect(unique.size).toBe(TRANSACTION_STATUSES.length);
   });
 
-  it('returns true for terminal statuses', () => {
-    const terminalStatuses: TransactionStatus[] = [
+  it('returns the expected result for every valid status', () => {
+    const terminalStatuses = new Set<TerminalTransactionStatus>([
       'completed',
       'refunded',
       'expired',
@@ -43,24 +44,27 @@ describe('TransactionStatus', () => {
       'no_market',
       'too_small',
       'too_large',
-    ];
+    ]);
 
-    expect(terminalStatuses.every((status) => isTerminalTransactionStatus(status))).toBe(true);
+    for (const status of TRANSACTION_STATUSES) {
+      expect(isTerminalTransactionStatus(status)).toBe(terminalStatuses.has(status));
+    }
   });
 
-  it('returns false for non-terminal statuses', () => {
-    const nonTerminalStatuses: TransactionStatus[] = [
-      'incomplete',
-      'pending_anchor',
-      'pending_user_transfer_start',
-      'pending_user_transfer_complete',
-      'pending_external',
-      'pending_trust',
-      'pending_user',
-      'pending_stellar',
-    ];
+  it('acts as a type guard for terminal statuses', () => {
+    const terminalStatuses = TRANSACTION_STATUSES.filter(isTerminalTransactionStatus);
 
-    expect(nonTerminalStatuses.some((status) => isTerminalTransactionStatus(status))).toBe(false);
+    const narrowed: TerminalTransactionStatus[] = terminalStatuses;
+
+    expect(narrowed).toEqual([
+      'completed',
+      'refunded',
+      'expired',
+      'error',
+      'no_market',
+      'too_small',
+      'too_large',
+    ] satisfies TerminalTransactionStatus[]);
   });
 
   // -- compile-time checks (tsc catches these before tests even run) --

--- a/tests/types/transaction-status.test.ts
+++ b/tests/types/transaction-status.test.ts
@@ -1,4 +1,8 @@
-import { TRANSACTION_STATUSES, type TransactionStatus } from '@/types/index.ts';
+import {
+  isTerminalTransactionStatus,
+  TRANSACTION_STATUSES,
+  type TransactionStatus,
+} from '@/types/index.ts';
 
 describe('TransactionStatus', () => {
   // -- runtime checks on the status array --
@@ -28,6 +32,35 @@ describe('TransactionStatus', () => {
   it('contains no duplicates', () => {
     const unique = new Set(TRANSACTION_STATUSES);
     expect(unique.size).toBe(TRANSACTION_STATUSES.length);
+  });
+
+  it('returns true for terminal statuses', () => {
+    const terminalStatuses: TransactionStatus[] = [
+      'completed',
+      'refunded',
+      'expired',
+      'error',
+      'no_market',
+      'too_small',
+      'too_large',
+    ];
+
+    expect(terminalStatuses.every((status) => isTerminalTransactionStatus(status))).toBe(true);
+  });
+
+  it('returns false for non-terminal statuses', () => {
+    const nonTerminalStatuses: TransactionStatus[] = [
+      'incomplete',
+      'pending_anchor',
+      'pending_user_transfer_start',
+      'pending_user_transfer_complete',
+      'pending_external',
+      'pending_trust',
+      'pending_user',
+      'pending_stellar',
+    ];
+
+    expect(nonTerminalStatuses.some((status) => isTerminalTransactionStatus(status))).toBe(false);
   });
 
   // -- compile-time checks (tsc catches these before tests even run) --


### PR DESCRIPTION
## What does this PR do?

Adds a public `isTerminalTransactionStatus(status: TransactionStatus): boolean` helper, documents the set of terminal transaction statuses in the helper JSDoc, and exports the helper through the public types barrel.

## How to test?

Run:

```bash
bun test tests/types/transaction-status.test.ts
bun run test
bun run lint
```

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #131
