### PR TITLE
fix: validate payment XDR account addresses

### DIFF
--- a/src/utils/stellar.ts
+++ b/src/utils/stellar.ts
@@ -123,6 +123,10 @@ export const StellarUtils = {
       throw new Error('destination must be a valid Stellar public or muxed public key');
     }
 
+    if (assetCode !== 'XLM' && !StrKey.isValidEd25519PublicKey(issuer ?? '')) {
+      throw new Error('issuer must be a valid Stellar public key for non-native assets');
+    }
+
     const networkPassphrase =
       network === 'public'
         ? Networks.PUBLIC

--- a/src/utils/stellar.ts
+++ b/src/utils/stellar.ts
@@ -1,9 +1,12 @@
 import {
+  Account,
   Memo as StellarMemo,
   TransactionBuilder,
   Asset,
+  MuxedAccount,
   Networks,
   Operation,
+  StrKey,
   Transaction,
 } from '@stellar/stellar-sdk';
 import { ValidationUtils } from './validation';
@@ -112,6 +115,14 @@ export const StellarUtils = {
   async buildPaymentXdr(params: PaymentParams): Promise<string> {
     const { source, destination, amount, assetCode, issuer, memo, network } = params;
 
+    if (!isValidPaymentAccountAddress(source)) {
+      throw new Error('source must be a valid Stellar public or muxed public key');
+    }
+
+    if (!isValidPaymentAccountAddress(destination)) {
+      throw new Error('destination must be a valid Stellar public or muxed public key');
+    }
+
     const networkPassphrase =
       network === 'public'
         ? Networks.PUBLIC
@@ -123,11 +134,9 @@ export const StellarUtils = {
 
     // We use a dummy sequence number because the actual submission will be handled later
     // or by a signer that manages sequence numbers.
-    const sourceAccount = {
-      sequenceNumber: () => '0',
-      incrementSequenceNumber: () => {},
-      accountId: () => source,
-    };
+    const sourceAccount = StrKey.isValidMed25519PublicKey(source)
+      ? MuxedAccount.fromAddress(source, '0')
+      : new Account(source, '0');
 
     const builder = new TransactionBuilder(sourceAccount, {
       fee: '100',
@@ -176,3 +185,7 @@ export const StellarUtils = {
     return ValidationUtils.isValidStellarAddress(accountId);
   },
 };
+
+function isValidPaymentAccountAddress(address: string): boolean {
+  return StrKey.isValidEd25519PublicKey(address) || StrKey.isValidMed25519PublicKey(address);
+}

--- a/tests/utils/stellar.test.ts
+++ b/tests/utils/stellar.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { Account, Keypair, MuxedAccount } from '@stellar/stellar-sdk';
 import { StellarUtils } from '@/utils/stellar.ts';
 
 interface ParsedPaymentOperation {
@@ -90,6 +91,48 @@ describe('StellarUtils', () => {
       const operation = asPaymentOperation(parsed.operations[0]);
       expect(operation.asset?.isNative()).toBe(true);
       expect(parseFloat(operation.amount)).toBe(parseFloat(params.amount));
+    });
+
+    it('should fail early for an invalid source public key', async () => {
+      await expect(
+        StellarUtils.buildPaymentXdr({
+          source: invalidAccountId,
+          destination: validAccountId,
+          amount: '1',
+          assetCode: 'XLM',
+          network: 'testnet',
+        }),
+      ).rejects.toThrow('source must be a valid Stellar public or muxed public key');
+    });
+
+    it('should fail early for an invalid destination public key', async () => {
+      await expect(
+        StellarUtils.buildPaymentXdr({
+          source: validAccountId,
+          destination: invalidAccountId,
+          amount: '1',
+          assetCode: 'XLM',
+          network: 'testnet',
+        }),
+      ).rejects.toThrow('destination must be a valid Stellar public or muxed public key');
+    });
+
+    it('should accept muxed source and destination accounts', async () => {
+      const baseAccount = Keypair.random().publicKey();
+      const source = new MuxedAccount(new Account(baseAccount, '0'), '123').accountId();
+      const destination = new MuxedAccount(new Account(baseAccount, '0'), '456').accountId();
+
+      const xdr = await StellarUtils.buildPaymentXdr({
+        source,
+        destination,
+        amount: '1',
+        assetCode: 'XLM',
+        network: 'testnet',
+      });
+
+      const parsed = StellarUtils.parseXdrTransaction(xdr);
+      expect(parsed.source).toBe(source);
+      expect(parsed.operations.length).toBe(1);
     });
 
     it('should throw when parsing invalid XDR', () => {

--- a/tests/utils/stellar.test.ts
+++ b/tests/utils/stellar.test.ts
@@ -117,6 +117,19 @@ describe('StellarUtils', () => {
       ).rejects.toThrow('destination must be a valid Stellar public or muxed public key');
     });
 
+    it('should fail early for an invalid issuer on non-native assets', async () => {
+      await expect(
+        StellarUtils.buildPaymentXdr({
+          source: validAccountId,
+          destination: validAccountId,
+          amount: '1',
+          assetCode: 'USDC',
+          issuer: invalidAccountId,
+          network: 'testnet',
+        }),
+      ).rejects.toThrow('issuer must be a valid Stellar public key for non-native assets');
+    });
+
     it('should accept muxed source and destination accounts', async () => {
       const baseAccount = Keypair.random().publicKey();
       const source = new MuxedAccount(new Account(baseAccount, '0'), '123').accountId();


### PR DESCRIPTION
## What does this PR do?

Adds upfront validation for payment XDR account addresses in `StellarUtils.buildPaymentXdr()`, so invalid source and destination inputs fail early with clear errors while still accepting valid muxed (`M...`) addresses supported by the Stellar SDK.

## How to test?

- `bun test tests/utils/stellar.test.ts`
- `bun test`
- `bun run lint`

You can also verify manually that:
- invalid `source` rejects with `source must be a valid Stellar public or muxed public key`
- invalid `destination` rejects with `destination must be a valid Stellar public or muxed public key`
- valid muxed source and destination addresses still build successfully

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #135
