### PR TITLE
feat(types): add isTransactionStatus runtime guard and tests

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export {
   TRANSACTION_STATUSES,
   isPendingTransactionStatus,
   isTerminalTransactionStatus,
+  isTransactionStatus,
 } from './transaction-status.ts';
 export type {
   PendingTransactionStatus,

--- a/src/types/transaction-status.ts
+++ b/src/types/transaction-status.ts
@@ -41,6 +41,14 @@ const TERMINAL_TRANSACTION_STATUSES = [
 export type TerminalTransactionStatus = (typeof TERMINAL_TRANSACTION_STATUSES)[number];
 
 /**
+ * Runtime guard that validates arbitrary input is a `TransactionStatus`.
+ * Uses the canonical `TRANSACTION_STATUSES` array as the single source of truth.
+ */
+export function isTransactionStatus(value: unknown): value is TransactionStatus {
+  return typeof value === 'string' && (TRANSACTION_STATUSES as readonly string[]).includes(value);
+}
+
+/**
  * Returns true when a transaction can no longer make progress.
  *
  * Terminal statuses:

--- a/tests/types/is-transaction-status.test.ts
+++ b/tests/types/is-transaction-status.test.ts
@@ -1,0 +1,23 @@
+import { isTransactionStatus, TRANSACTION_STATUSES } from '@/types/index.ts';
+
+describe('isTransactionStatus', () => {
+  it('returns true for every valid status', () => {
+    for (const s of TRANSACTION_STATUSES) {
+      expect(isTransactionStatus(s)).toBe(true);
+    }
+  });
+
+  it('returns false for invalid strings', () => {
+    expect(isTransactionStatus('not_a_status')).toBe(false);
+    expect(isTransactionStatus('Completed')).toBe(false);
+    expect(isTransactionStatus('pending')).toBe(false);
+  });
+
+  it('returns false for non-string inputs', () => {
+    expect(isTransactionStatus(null)).toBe(false);
+    expect(isTransactionStatus(undefined)).toBe(false);
+    expect(isTransactionStatus(123)).toBe(false);
+    expect(isTransactionStatus({})).toBe(false);
+    expect(isTransactionStatus([])).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Summary:
Adds a small, public runtime type guard [isTransactionStatus(value: unknown): value is TransactionStatus](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that validates untyped input against the canonical [TRANSACTION_STATUSES](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) list. The helper is implemented using the existing [TRANSACTION_STATUSES](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) array so the list remains the single source of truth.

Please describe how to verify the changes.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #130 
