### PR TITLE
test(sqlite): add idempotency persistence test for sqlite adapter (is…

### DIFF
--- a/tests/sqlite-idempotency.test.ts
+++ b/tests/sqlite-idempotency.test.ts
@@ -23,7 +23,7 @@ describe('sqlite idempotency persistence', () => {
 
     db.run(
       'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
-      [scope, key, hash, status, JSON.stringify(response)]
+      [scope, key, hash, status, JSON.stringify(response)],
     );
 
     const all = [...db.query('SELECT scope, id_key, hash, status, response FROM idempotency')];

--- a/tests/sqlite-idempotency.test.ts
+++ b/tests/sqlite-idempotency.test.ts
@@ -1,0 +1,53 @@
+import Database from 'bun:sqlite';
+
+describe('sqlite idempotency persistence', () => {
+  it('stores and fetches an idempotency record by scope and key', () => {
+    const db = new Database(':memory:');
+
+    db.run(
+      `CREATE TABLE IF NOT EXISTS idempotency (
+        scope TEXT NOT NULL,
+        id_key TEXT NOT NULL,
+        hash TEXT NOT NULL,
+        status INTEGER NOT NULL,
+        response TEXT NOT NULL,
+        PRIMARY KEY(scope, id_key)
+      )`
+    );
+
+    const scope = 'sep24:deposit';
+    const key = 'client-123';
+    const hash = 'abcd1234';
+    const status = 200;
+    const response = { message: 'ok', id: 'resp-1' };
+
+    db.run(
+      'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
+      scope,
+      key,
+      hash,
+      status,
+      JSON.stringify(response)
+    );
+
+    const all = [...db.query('SELECT scope, id_key, hash, status, response FROM idempotency')];
+    expect(all.length).toBe(1);
+
+    const inserted = all[0] as { scope: string; id_key: string; hash: string; status: number; response: string };
+    expect(inserted.scope).toBe(scope);
+    expect(inserted.id_key).toBe(key);
+    expect(inserted.hash).toBe(hash);
+    expect(inserted.status).toBe(status);
+    expect(JSON.parse(inserted.response)).toEqual(response);
+
+    const rows = [...db.query(`SELECT scope, id_key, hash, status, response FROM idempotency WHERE scope = '${scope}' AND id_key = '${key}'`)];
+    expect(rows.length).toBe(1);
+
+    const fetched = rows[0] as { scope: string; id_key: string; hash: string; status: number; response: string };
+    expect(fetched.scope).toBe(scope);
+    expect(fetched.id_key).toBe(key);
+    expect(fetched.hash).toBe(hash);
+    expect(fetched.status).toBe(status);
+    expect(JSON.parse(fetched.response)).toEqual(response);
+  });
+});

--- a/tests/sqlite-idempotency.test.ts
+++ b/tests/sqlite-idempotency.test.ts
@@ -12,7 +12,7 @@ describe('sqlite idempotency persistence', () => {
         status INTEGER NOT NULL,
         response TEXT NOT NULL,
         PRIMARY KEY(scope, id_key)
-      )`
+      )`,
     );
 
     const scope = 'sep24:deposit';
@@ -23,27 +23,42 @@ describe('sqlite idempotency persistence', () => {
 
     db.run(
       'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
-      scope,
-      key,
-      hash,
-      status,
-      JSON.stringify(response)
+      [scope, key, hash, status, JSON.stringify(response)]
     );
 
     const all = [...db.query('SELECT scope, id_key, hash, status, response FROM idempotency')];
     expect(all.length).toBe(1);
 
-    const inserted = all[0] as { scope: string; id_key: string; hash: string; status: number; response: string };
+    const inserted = all[0] as {
+      scope: string;
+      id_key: string;
+      hash: string;
+      status: number;
+      response: string;
+    };
+
     expect(inserted.scope).toBe(scope);
     expect(inserted.id_key).toBe(key);
     expect(inserted.hash).toBe(hash);
     expect(inserted.status).toBe(status);
     expect(JSON.parse(inserted.response)).toEqual(response);
 
-    const rows = [...db.query(`SELECT scope, id_key, hash, status, response FROM idempotency WHERE scope = '${scope}' AND id_key = '${key}'`)];
+    const rows = [
+      ...db.query(
+        `SELECT scope, id_key, hash, status, response FROM idempotency WHERE scope = '${scope}' AND id_key = '${key}'`,
+      ),
+    ];
+
     expect(rows.length).toBe(1);
 
-    const fetched = rows[0] as { scope: string; id_key: string; hash: string; status: number; response: string };
+    const fetched = rows[0] as {
+      scope: string;
+      id_key: string;
+      hash: string;
+      status: number;
+      response: string;
+    };
+
     expect(fetched.scope).toBe(scope);
     expect(fetched.id_key).toBe(key);
     expect(fetched.hash).toBe(hash);


### PR DESCRIPTION
### Summary (issue #120)

Adds a focused SQLite adapter test for idempotency persistence. The new test inserts an idempotency record into an in-memory SQLite database, queries it back by `scope` and `id_key`, and verifies that `hash`, `status`, and `response` are preserved.

## How to test?
- Run `bun test tests/sqlite-idempotency.test.ts`
- Optionally run `bun test` to ensure the full suite still passes

## Checklist
- [ ] My code follows the code style of this project.
- [ ] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `bun run test` and `bun run lint` locally.

Closes #120 