### PR TITLE
Document webhook raw body capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ import express from 'express';
 import { createAnchor } from 'anchor-kit';
 
 const app = express();
-app.use(express.json());
+app.use(
+  express.json({
+    verify: (req, _res, buf) => {
+      (req as { rawBody?: string }).rawBody = buf.toString('utf8');
+    },
+  }),
+);
 
 const anchor = createAnchor({
   network: { network: 'testnet' },
@@ -94,6 +100,12 @@ app.use('/anchor', anchor.getExpressRouter());
 
 app.listen(3000);
 ```
+
+### Webhook raw body capture
+
+Webhook signature verification signs the exact request body bytes, so Anchor-Kit must receive the unmodified raw body. If Express parses or normalizes JSON before the SDK can verify the signature, an otherwise valid `x-anchor-signature` can fail.
+
+When mounting Anchor-Kit behind Express, configure `express.json()` with a `verify` hook before `anchor.getExpressRouter()` and store `req.rawBody`, as shown in the Quick Start. Verify the webhook signature before parsing, transforming, or rebuilding the body for any custom middleware.
 
 ## Testing
 

--- a/tests/readme-webhook-raw-body.test.ts
+++ b/tests/readme-webhook-raw-body.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('README webhook raw body guidance', () => {
+  it('documents Express raw body capture for webhook signature verification', () => {
+    const readme = readFileSync(join(process.cwd(), 'README.md'), 'utf8');
+
+    expect(readme).toContain('Webhook raw body capture');
+    expect(readme).toContain('express.json({');
+    expect(readme).toContain('verify: (req, _res, buf)');
+    expect(readme).toContain('rawBody');
+    expect(readme).toContain('exact request body bytes');
+    expect(readme).toContain('before `anchor.getExpressRouter()`');
+  });
+});

--- a/tests/readme-webhook-raw-body.test.ts
+++ b/tests/readme-webhook-raw-body.test.ts
@@ -1,16 +1,16 @@
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('README webhook raw body guidance', () => {
   it('documents Express raw body capture for webhook signature verification', () => {
-    const readme = readFileSync(join(process.cwd(), 'README.md'), 'utf8');
+    const readmePath = new URL('../README.md', import.meta.url);
+    const readme = readFileSync(readmePath, 'utf8');
 
     expect(readme).toContain('Webhook raw body capture');
-    expect(readme).toContain('express.json({');
-    expect(readme).toContain('verify: (req, _res, buf)');
+    expect(readme).toContain('express.json');
+    expect(readme).toContain('verify');
     expect(readme).toContain('rawBody');
     expect(readme).toContain('exact request body bytes');
-    expect(readme).toContain('before `anchor.getExpressRouter()`');
+    expect(readme).toContain('anchor.getExpressRouter()');
   });
 });


### PR DESCRIPTION
## Summary
- update the README Quick Start to capture Express rawBody through the json parser verify hook
- add a webhook raw-body note explaining why signature verification needs exact request bytes
- add a focused README test that keeps the Express rawBody guidance present

Fixes #139

## Verification
- PASS: bun test tests/readme-webhook-raw-body.test.ts
- ATTEMPTED: bun test after bun install; fails on existing repo/runtime issues unrelated to this docs change: Bun TextDecoder does not support utf-16be in the jsdom/isomorphic-dompurify path, and tests/types/transaction.test.ts imports expectTypeOf from vitest at runtime under Bun. The new README test passes in that full run before the unrelated failures.