### PR TITLE
feat(validation): export SecurityConfigSchema from public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export * from './types';
 export { AnchorInstance, createAnchor, makeSqliteDbUrlForTests } from './core/factory';
 export * from './core/errors';
 export * as utils from './utils';
-export { AssetSchema, DatabaseUrlSchema } from './utils';
+export { AssetSchema, DatabaseUrlSchema, SecurityConfigSchema } from './utils';
 export type {
   DatabaseAdapter,
   QueueAdapter,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,4 +1,4 @@
-import type { AnchorKitConfig, NetworkConfig } from '@/types/config.ts';
+import type { AnchorKitConfig, NetworkConfig, SecurityConfig } from '@/types/config.ts';
 import DOMPurify from 'isomorphic-dompurify';
 
 /**
@@ -170,6 +170,33 @@ export const NetworkConfigSchema = {
 };
 
 /**
+ * SecurityConfigSchema - Public validation helper for the security configuration section.
+ *
+ * Integrators building their own config tooling can import this to validate just the
+ * security block without going through the top-level AnchorKitConfigSchema.
+ */
+export const SecurityConfigSchema = {
+  /**
+   * Validates a SecurityConfig object.
+   * Throws an error if validation fails.
+   *
+   * @param config The SecurityConfig object to validate.
+   */
+  validate(config: SecurityConfig): void {
+    if (!config) throw new Error('Missing required top-level field: security');
+    if (!config.sep10SigningKey)
+      throw new Error('Missing required secret: security.sep10SigningKey');
+    if (!config.interactiveJwtSecret)
+      throw new Error('Missing required secret: security.interactiveJwtSecret');
+    if (!config.distributionAccountSecret)
+      throw new Error('Missing required secret: security.distributionAccountSecret');
+    if (config.authTokenLifetimeSeconds !== undefined && config.authTokenLifetimeSeconds <= 0) {
+      throw new Error('security.authTokenLifetimeSeconds must be > 0');
+    }
+  },
+};
+
+/**
  * AnchorKitConfigSchema - Public validation helper for the top-level configuration object.
  */
 export const AnchorKitConfigSchema = {
@@ -195,15 +222,7 @@ export const AnchorKitConfigSchema = {
     NetworkConfigSchema.validate(network);
 
     // Security Section
-    if (!security.sep10SigningKey)
-      throw new Error('Missing required secret: security.sep10SigningKey');
-    if (!security.interactiveJwtSecret)
-      throw new Error('Missing required secret: security.interactiveJwtSecret');
-    if (!security.distributionAccountSecret)
-      throw new Error('Missing required secret: security.distributionAccountSecret');
-    if (security.authTokenLifetimeSeconds !== undefined && security.authTokenLifetimeSeconds <= 0) {
-      throw new Error('security.authTokenLifetimeSeconds must be > 0');
-    }
+    SecurityConfigSchema.validate(security);
 
     // Assets Section
     if (!assets.assets || !Array.isArray(assets.assets) || assets.assets.length === 0) {

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,9 +1,11 @@
 import {
   AnchorKitConfigSchema,
   NetworkConfigSchema,
+  SecurityConfigSchema,
   ValidationUtils,
 } from '../../src/utils/validation';
-import type { AnchorKitConfig } from '../../src/types/config';
+import { SecurityConfigSchema as PublicSecurityConfigSchema } from '../../src';
+import type { AnchorKitConfig, SecurityConfig } from '../../src/types/config';
 
 describe('ValidationUtils', () => {
   describe('isValidEmail', () => {
@@ -140,6 +142,56 @@ describe('NetworkConfigSchema', () => {
         horizonUrl: 'not-a-url',
       }),
     ).toThrow(/Invalid URL format/);
+  });
+});
+
+describe('SecurityConfigSchema', () => {
+  const validSecurity: SecurityConfig = {
+    sep10SigningKey: 'SD6P3...',
+    interactiveJwtSecret: 'shhh',
+    distributionAccountSecret: 'SD7Q4...',
+  };
+
+  test('is publicly reachable from the package entry point', () => {
+    expect(PublicSecurityConfigSchema).toBe(SecurityConfigSchema);
+    expect(typeof PublicSecurityConfigSchema.validate).toBe('function');
+  });
+
+  test('validates a correct SecurityConfig without throwing', () => {
+    expect(() => SecurityConfigSchema.validate(validSecurity)).not.toThrow();
+  });
+
+  test('throws when the security block itself is missing', () => {
+    // @ts-expect-error test case
+    expect(() => SecurityConfigSchema.validate(undefined)).toThrow(/security/);
+  });
+
+  test('throws for each required secret independently', () => {
+    expect(() =>
+      SecurityConfigSchema.validate({ ...validSecurity, sep10SigningKey: '' }),
+    ).toThrow(/sep10SigningKey/);
+    expect(() =>
+      SecurityConfigSchema.validate({ ...validSecurity, interactiveJwtSecret: '' }),
+    ).toThrow(/interactiveJwtSecret/);
+    expect(() =>
+      SecurityConfigSchema.validate({ ...validSecurity, distributionAccountSecret: '' }),
+    ).toThrow(/distributionAccountSecret/);
+  });
+
+  test('throws when authTokenLifetimeSeconds is not strictly positive', () => {
+    expect(() =>
+      SecurityConfigSchema.validate({ ...validSecurity, authTokenLifetimeSeconds: 0 }),
+    ).toThrow(/authTokenLifetimeSeconds/);
+    expect(() =>
+      SecurityConfigSchema.validate({ ...validSecurity, authTokenLifetimeSeconds: -1 }),
+    ).toThrow(/authTokenLifetimeSeconds/);
+  });
+
+  test('allows authTokenLifetimeSeconds when undefined or positive', () => {
+    expect(() => SecurityConfigSchema.validate(validSecurity)).not.toThrow();
+    expect(() =>
+      SecurityConfigSchema.validate({ ...validSecurity, authTokenLifetimeSeconds: 3600 }),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Closes #128

## Summary
Adds a new `SecurityConfigSchema` to `src/utils/validation.ts` (matching the existing `NetworkConfigSchema` / `AnchorKitConfigSchema` pattern) and re-exports it from the public API so integrators can validate just the security block when building their own config tooling.

## Changes
- **`src/utils/validation.ts`** — new `SecurityConfigSchema.validate(config: SecurityConfig)` lifting the security-section checks (sep10SigningKey, interactiveJwtSecret, distributionAccountSecret, authTokenLifetimeSeconds) out of the top-level validator.
- **`src/utils/validation.ts`** — refactor `AnchorKitConfigSchema.validate` to delegate to `SecurityConfigSchema.validate(security)`. Top-level behaviour is unchanged.
- **`src/index.ts`** — re-export `SecurityConfigSchema` alongside `AssetSchema` and `DatabaseUrlSchema`.
- **`tests/utils/validation.test.ts`** — focused tests proving the schema is publicly reachable and that each invariant throws as expected.

No new runtime dependencies. Bun + TypeScript per contributor notes.

## Test plan
- [x] \`bun test tests/utils/validation.test.ts\` — 27 pass / 0 fail
- [x] Full suite (\`bun test\`) — 317 pass / 0 fail
- [x] Existing \`AnchorKitConfigSchema\` tests still pass (behaviour unchanged for top-level validation)
- [x] New tests confirm \`import { SecurityConfigSchema } from 'anchor-kit'\` works