### PR TITLE
feat(sep24): add account field to interactive deposit create response

### DIFF
--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -539,6 +539,7 @@ export class AnchorExpressRouter {
           amount: created.amount,
           asset_code: created.assetCode,
           asset_issuer: selectedAsset.issuer,
+          account: created.account,
           interactive_url: `${this.config.get('server').interactiveDomain ?? 'http://localhost:3000'}/deposit/${created.id}`,
           created_at: created.createdAt,
         },

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -554,6 +554,7 @@ describe('MVP Express-mounted integration', () => {
     expect(response.body.asset_issuer).toBe(
       'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
     );
+    expect(response.body.account).toBe(clientKeypair.publicKey());
     expect(response.body).not.toHaveProperty('idempotency_replay');
   });
 
@@ -589,6 +590,7 @@ describe('MVP Express-mounted integration', () => {
     expect(response.body.id).toBe(transactionId);
     expect(response.body.interactive_url).toBe(depositInteractiveUrl);
     expect(response.body.status).toBe('pending_user_transfer_start');
+    expect(response.body.account).toBe(clientKeypair.publicKey());
     expect(response.body.idempotency_replay).toBe(true);
   });
 
@@ -1012,6 +1014,7 @@ describe('MVP Express-mounted integration', () => {
     });
 
     expect(firstResponse.status).toBe(201);
+    expect(firstResponse.body.account).toBe(clientKeypair.publicKey());
     const firstTxId = firstResponse.body.id;
 
     const secondResponse = await invoke({


### PR DESCRIPTION
The POST /transactions/deposit/interactive response now includes an 'account' field populated with the authenticated Stellar account from the bearer token JWT's 'sub' claim.

This makes the create response self-contained and consistent with the GET /transactions/:id lookup response, which already returned the 'account' field.

Changes:
- src/runtime/http/express-router.ts: added account: created.account to the response body at line 543
- tests/mvp-express.integration.test.ts: added assertions in tests 6, 6c, and 12 verifying that the response.account matches the authenticated clientKeypair.publicKey()

Closes #219