### PR TITLE
fix: move test-only and type-only packages from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,18 +35,13 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.6.0",
-    "@types/bcryptjs": "^3.0.0",
-    "@types/express": "^5.0.6",
-    "@types/jsonwebtoken": "^9.0.10",
-    "@types/supertest": "^7.2.0",
     "bcryptjs": "^3.0.3",
     "big.js": "^7.0.1",
     "express": "^5.2.1",
     "isomorphic-dompurify": "^3.0.0",
     "jose": "^6.1.3",
     "jsonwebtoken": "^9.0.3",
-    "pg": "^8.19.0",
-    "supertest": "^7.2.2"
+    "pg": "^8.19.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -62,6 +57,11 @@
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
     "typescript-eslint": "^8.55.0",
+    "@types/bcryptjs": "^3.0.0",
+    "@types/express": "^5.0.6",
+    "@types/jsonwebtoken": "^9.0.10",
+    "@types/supertest": "^7.2.0",
+    "supertest": "^7.2.2",
     "vitest": "^4.0.18"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Moves test-only and type-only packages out of `dependencies` into `devDependencies`:

- **`supertest`** – test-only, belongs in dev tooling
- **`@types/bcryptjs`**, **`@types/express`**, **`@types/jsonwebtoken`**, **`@types/supertest`** – compile-time only, not needed at runtime

Library consumers were installing extra packages with no production value, increasing install size and dependency surface.

Closes #208