### PR TITLE
fix(http): return 4xx for invalid POST request bodies (#231)

### DIFF
--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -46,6 +46,18 @@ export class ValidationError extends AnchorKitError {
 }
 
 /**
+ * Error raised when a request body exceeds the configured size limit.
+ */
+export class PayloadTooLargeError extends AnchorKitError {
+  public readonly statusCode = 413;
+  public readonly errorCode = 'PAYLOAD_TOO_LARGE';
+
+  constructor(message: string, context?: Record<string, unknown>) {
+    super(message, context);
+  }
+}
+
+/**
  * Error representing a standard SEP protocol error.
  */
 export class SepProtocolError extends AnchorKitError {

--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -1,6 +1,6 @@
 import { version } from '../../../package.json';
 import type { AnchorConfig } from '@/core/config.ts';
-import { ValidationError } from '@/core/errors.ts';
+import { PayloadTooLargeError, ValidationError } from '@/core/errors.ts';
 import { InMemoryRateLimiter, type RateLimitRule } from '@/runtime/http/rate-limiter.ts';
 import type { DatabaseAdapter, WebhookProcessor } from '@/runtime/interfaces.ts';
 import {
@@ -63,7 +63,7 @@ async function readRawBody(req: IncomingMessage, maxBodyBytes: number): Promise<
   const reqWithRaw = req as IncomingMessage & RawBodyCarrier;
   if (typeof reqWithRaw.rawBody === 'string') {
     if (getBodyByteLength(reqWithRaw.rawBody) > maxBodyBytes) {
-      throw new ValidationError(`Request body too large. Max ${maxBodyBytes} bytes`);
+      throw new PayloadTooLargeError(`Request body too large. Max ${maxBodyBytes} bytes`);
     }
     return reqWithRaw.rawBody;
   }
@@ -73,7 +73,7 @@ async function readRawBody(req: IncomingMessage, maxBodyBytes: number): Promise<
     const serialized =
       typeof bodyFromFramework === 'string' ? bodyFromFramework : JSON.stringify(bodyFromFramework);
     if (getBodyByteLength(serialized) > maxBodyBytes) {
-      throw new ValidationError(`Request body too large. Max ${maxBodyBytes} bytes`);
+      throw new PayloadTooLargeError(`Request body too large. Max ${maxBodyBytes} bytes`);
     }
     return serialized;
   }
@@ -84,7 +84,7 @@ async function readRawBody(req: IncomingMessage, maxBodyBytes: number): Promise<
     const chunkBuffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
     totalBytes += chunkBuffer.byteLength;
     if (totalBytes > maxBodyBytes) {
-      throw new ValidationError(`Request body too large. Max ${maxBodyBytes} bytes`);
+      throw new PayloadTooLargeError(`Request body too large. Max ${maxBodyBytes} bytes`);
     }
     chunks.push(chunkBuffer);
   }
@@ -94,12 +94,51 @@ async function readRawBody(req: IncomingMessage, maxBodyBytes: number): Promise<
 function jsonParseObject(rawBody: string): Record<string, unknown> {
   if (!rawBody) return {};
 
-  const parsed: unknown = JSON.parse(rawBody);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    throw new ValidationError('Request body must be valid JSON');
+  }
+
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new ValidationError('Request JSON body must be an object');
   }
 
   return parsed as Record<string, unknown>;
+}
+
+async function parsePostJsonBody(
+  req: IncomingMessage,
+  res: ServerResponse,
+  maxBodyBytes: number,
+): Promise<{ rawBody: string; body: Record<string, unknown> } | null> {
+  let rawBody: string;
+  try {
+    rawBody = await readRawBody(req, maxBodyBytes);
+  } catch (error) {
+    if (error instanceof PayloadTooLargeError) {
+      sendJson(res, 413, {
+        error: 'payload_too_large',
+        message: error.message,
+      });
+      return null;
+    }
+    throw error;
+  }
+
+  try {
+    return { rawBody, body: jsonParseObject(rawBody) };
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      sendJson(res, 400, {
+        error: 'invalid_request',
+        message: error.message,
+      });
+      return null;
+    }
+    throw error;
+  }
 }
 
 function sha256(input: string): string {
@@ -331,8 +370,11 @@ export class AnchorExpressRouter {
         return;
       }
 
-      const rawBody = await readRawBody(req, this.maxBodyBytes);
-      const body = jsonParseObject(rawBody);
+      const parsedBody = await parsePostJsonBody(req, res, this.maxBodyBytes);
+      if (!parsedBody) {
+        return;
+      }
+      const { body } = parsedBody;
       const account = typeof body.account === 'string' ? body.account : '';
       const signedChallenge = typeof body.challenge === 'string' ? body.challenge : '';
 
@@ -446,8 +488,11 @@ export class AnchorExpressRouter {
         return;
       }
 
-      const rawBody = await readRawBody(req, this.maxBodyBytes);
-      const body = jsonParseObject(rawBody);
+      const parsedBody = await parsePostJsonBody(req, res, this.maxBodyBytes);
+      if (!parsedBody) {
+        return;
+      }
+      const { body } = parsedBody;
       const assetCode = typeof body.asset_code === 'string' ? body.asset_code : '';
       const amountRaw = body.amount;
       const amount =
@@ -612,8 +657,11 @@ export class AnchorExpressRouter {
         return;
       }
 
-      const rawBody = await readRawBody(req, this.maxBodyBytes);
-      const payload = jsonParseObject(rawBody);
+      const parsedBody = await parsePostJsonBody(req, res, this.maxBodyBytes);
+      if (!parsedBody) {
+        return;
+      }
+      const { rawBody, body: payload } = parsedBody;
       const eventIdField = payload.id;
       const eventId =
         typeof eventIdField === 'string' && eventIdField.length > 0 ? eventIdField : randomUUID();

--- a/tests/core/errors.test.ts
+++ b/tests/core/errors.test.ts
@@ -4,6 +4,7 @@ import {
   RailError,
   ConfigError,
   ValidationError,
+  PayloadTooLargeError,
   SepProtocolError,
   NetworkError,
   CryptoError,
@@ -88,6 +89,14 @@ describe('ValidationError', () => {
     const err = new ValidationError('invalid parameter');
     expect(err.statusCode).toBe(400);
     expect(err.errorCode).toBe('INVALID_REQUEST');
+  });
+});
+
+describe('PayloadTooLargeError', () => {
+  it('maps statusCode and errorCode', () => {
+    const err = new PayloadTooLargeError('request body too large');
+    expect(err.statusCode).toBe(413);
+    expect(err.errorCode).toBe('PAYLOAD_TOO_LARGE');
   });
 });
 

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -19,13 +19,15 @@ interface TestRequestOptions {
   path: string;
   headers?: Record<string, string>;
   body?: Record<string, unknown>;
+  rawBody?: string;
 }
 
 function createMountedInvoker(anchor: AnchorInstance) {
   const middleware = anchor.getExpressRouter();
 
   return async (options: TestRequestOptions): Promise<TestResponse> => {
-    const serializedBody = options.body ? JSON.stringify(options.body) : '';
+    const serializedBody =
+      options.rawBody ?? (options.body ? JSON.stringify(options.body) : '');
 
     const req = Readable.from(serializedBody ? [serializedBody] : []) as IncomingMessage & {
       method: string;
@@ -1095,5 +1097,104 @@ describe('MVP Express-mounted integration', () => {
     expect(tokenResponse.status).toBe(401);
     expect(tokenResponse.body.error).toBe('invalid_challenge');
     expect(tokenResponse.body.message).toBe('Challenge not found');
+  });
+
+  it('15) malformed JSON on POST /auth/token returns 400', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/auth/token',
+      headers: { 'content-type': 'application/json' },
+      rawBody: '{not json',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.message).toBe('Request body must be valid JSON');
+  });
+
+  it('15b) malformed JSON on POST /transactions/deposit/interactive returns 400', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/transactions/deposit/interactive',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': 'application/json',
+      },
+      rawBody: '{"asset_code":',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.message).toBe('Request body must be valid JSON');
+  });
+
+  it('15c) malformed JSON on POST /webhooks/events returns 400', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/webhooks/events',
+      headers: { 'content-type': 'application/json' },
+      rawBody: 'not-json',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.message).toBe('Request body must be valid JSON');
+  });
+
+  it('15d) oversize body on POST /auth/token returns 413', async () => {
+    const customDbUrl = makeSqliteDbUrlForTests();
+    const customDbPath = customDbUrl.startsWith('file:')
+      ? customDbUrl.slice('file:'.length)
+      : customDbUrl;
+    const customAnchor = createAnchor({
+      network: { network: 'testnet' },
+      server: {},
+      security: {
+        sep10SigningKey: sep10ServerKeypair.secret(),
+        interactiveJwtSecret: 'jwt-test-secret',
+        distributionAccountSecret: 'distribution-test-secret',
+        webhookSecret: 'webhook-test-secret',
+      },
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+            deposits_enabled: true,
+          },
+        ],
+      },
+      framework: {
+        database: { provider: 'sqlite', url: customDbUrl },
+        http: { maxBodyBytes: 1024 },
+      },
+    });
+
+    await customAnchor.init();
+    const customInvoke = createMountedInvoker(customAnchor);
+
+    try {
+      const oversizedBody = JSON.stringify({
+        account: 'G'.repeat(1024),
+        challenge: 'x',
+      });
+      const response = await customInvoke({
+        method: 'POST',
+        path: '/auth/token',
+        headers: { 'content-type': 'application/json' },
+        rawBody: oversizedBody,
+      });
+
+      expect(response.status).toBe(413);
+      expect(response.body.error).toBe('payload_too_large');
+      expect(response.body.message).toBe('Request body too large. Max 1024 bytes');
+    } finally {
+      await customAnchor.shutdown();
+      try {
+        unlinkSync(customDbPath);
+      } catch {
+        // ignore cleanup errors in CI
+      }
+    }
   });
 });

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -26,8 +26,7 @@ function createMountedInvoker(anchor: AnchorInstance) {
   const middleware = anchor.getExpressRouter();
 
   return async (options: TestRequestOptions): Promise<TestResponse> => {
-    const serializedBody =
-      options.rawBody ?? (options.body ? JSON.stringify(options.body) : '');
+    const serializedBody = options.rawBody ?? (options.body ? JSON.stringify(options.body) : '');
 
     const req = Readable.from(serializedBody ? [serializedBody] : []) as IncomingMessage & {
       method: string;


### PR DESCRIPTION
Map malformed JSON to 400 invalid_request and oversize bodies to 413 payload_too_large on POST /auth/token, /transactions/deposit/interactive, and /webhooks/events. Add integration tests for both error paths.

## What does this PR do?

Please provide a brief description of the changes in this PR.

## How to test?

Please describe how to verify the changes.

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #231
