### PR TITLE
test: add integration coverage for invalid account in /auth/token body

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -389,6 +389,19 @@ describe('MVP Express-mounted integration', () => {
     }
   });
 
+  it('3c) auth token rejects invalid account', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/auth/token',
+      headers: { 'content-type': 'application/json' },
+      body: { account: 'not-a-stellar-key', challenge: 'some-challenge' },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.message).toBe('account must be a valid Stellar public key');
+  });
+
   it('4) unauthorized deposit interactive rejected', async () => {
     const response = await invoke({
       method: 'POST',


### PR DESCRIPTION
- closes #215 
Summary This PR adds integration test coverage for the POST /auth/token route to ensure it correctly validates the account field. While the route implementation already performed this validation, it lacked explicit coverage in the integration suite.

Changes

- Added a new test case in mvp-express.integration.test.ts that submits a syntactically invalid Stellar public key.
- Asserted that the route returns a 400 Bad Request with the appropriate error message.
Testing

- Verified the new test case passes by running bun test .
- Confirmed the entire integration suite remains healthy (34/34 tests passing).