### PR TITLE
Add focused divide-by-zero unit test and deposit rate-limit 429 integ…

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -591,7 +591,9 @@ describe('MVP Express-mounted integration', () => {
     expect(thirdResponse.headers['retry-after']).toBeDefined();
 
     await customAnchor.shutdown();
-    const customDbPath = customDbUrl.startsWith('file:') ? customDbUrl.slice('file:'.length) : customDbUrl;
+    const customDbPath = customDbUrl.startsWith('file:')
+      ? customDbUrl.slice('file:'.length)
+      : customDbUrl;
     try {
       unlinkSync(customDbPath);
     } catch {

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -518,6 +518,87 @@ describe('MVP Express-mounted integration', () => {
     }
   });
 
+  it('5f) deposit route returns 429 after exceeding configured depositMax', async () => {
+    const customDbUrl = makeSqliteDbUrlForTests();
+    const customAnchor = createAnchor({
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'https://anchor.example.com' },
+      security: {
+        sep10SigningKey: sep10ServerKeypair.secret(),
+        interactiveJwtSecret: 'jwt-test-secret-rate-limit',
+        distributionAccountSecret: 'distribution-test-secret',
+      },
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+            deposits_enabled: true,
+            min_amount: 10,
+            max_amount: 100,
+          },
+        ],
+      },
+      framework: {
+        database: { provider: 'sqlite', url: customDbUrl },
+        rateLimit: { windowMs: 60000, depositMax: 2 },
+      },
+    });
+
+    await customAnchor.init();
+    const customInvoke = createMountedInvoker(customAnchor);
+    const account = clientKeypair.publicKey();
+
+    const challengeResponse = await customInvoke({
+      path: `/auth/challenge?account=${account}`,
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+    });
+    expect(challengeResponse.status).toBe(200);
+    const challengeXdr = String(challengeResponse.body.challenge ?? '');
+    const networkPassphrase = String(challengeResponse.body.network_passphrase ?? '');
+    const challengeTx = new Transaction(challengeXdr, networkPassphrase);
+    challengeTx.sign(clientKeypair);
+
+    const tokenResponse = await customInvoke({
+      method: 'POST',
+      path: '/auth/token',
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '10.0.0.1' },
+      body: { account, challenge: challengeTx.toXDR() },
+    });
+    expect(tokenResponse.status).toBe(200);
+    const customToken = String(tokenResponse.body.token ?? '');
+
+    const depositRequest = {
+      method: 'POST',
+      path: '/transactions/deposit/interactive',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${customToken}`,
+        'x-forwarded-for': '10.0.0.1',
+      },
+      body: { asset_code: 'USDC', amount: '10' },
+    };
+
+    const firstResponse = await customInvoke(depositRequest);
+    expect(firstResponse.status).toBe(201);
+
+    const secondResponse = await customInvoke(depositRequest);
+    expect(secondResponse.status).toBe(201);
+
+    const thirdResponse = await customInvoke(depositRequest);
+    expect(thirdResponse.status).toBe(429);
+    expect(thirdResponse.body.error).toBe('rate_limited');
+    expect(thirdResponse.headers['retry-after']).toBeDefined();
+
+    await customAnchor.shutdown();
+    const customDbPath = customDbUrl.startsWith('file:') ? customDbUrl.slice('file:'.length) : customDbUrl;
+    try {
+      unlinkSync(customDbPath);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
   it('5b) deposit at max_amount boundary is accepted', async () => {
     const response = await invoke({
       method: 'POST',

--- a/tests/utils/decimal.test.ts
+++ b/tests/utils/decimal.test.ts
@@ -32,6 +32,10 @@ describe('DecimalUtils', () => {
       expect(DecimalUtils.divide('1', '3', 2)).toBe('0.33');
       expect(DecimalUtils.divide('10', '2', 2)).toBe('5.00');
     });
+
+    test('should throw when dividing by zero', () => {
+      expect(() => DecimalUtils.divide('1', '0')).toThrow('[big.js] Division by zero');
+    });
   });
 
   describe('applyFee', () => {


### PR DESCRIPTION
Summary
This PR adds focused coverage for two regression cases:

[DecimalUtils.divide](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) division by zero

Adds a unit test asserting [DecimalUtils.divide('1', '0')](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) throws.
Ensures the helper does not return a non-finite value for zero divisors.
Deposit route rate limit 429

Adds an integration test that configures [depositMax: 2](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Sends three authenticated deposit requests from the same client.
Verifies the third request returns 429 with [error: "rate_limited"](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and a retry-after header.


- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #234
Closes #259

