### PR TITLE
Add retry_after_seconds to rate limit responses

### DIFF
--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -670,6 +670,7 @@ export class AnchorExpressRouter {
       sendJson(res, 429, {
         error: 'rate_limited',
         message: 'Too many requests',
+        retry_after_seconds: result.retryAfterSeconds,
       });
       return false;
     }

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -314,6 +314,75 @@ describe('MVP Express-mounted integration', () => {
     expect(tokenResponse.body.expires_in).toBe(3600);
   });
 
+  it('3a) rate limit response body includes retry_after_seconds matching header', async () => {
+    const customDbUrl = makeSqliteDbUrlForTests();
+    const customDbPath = customDbUrl.startsWith('file:')
+      ? customDbUrl.slice('file:'.length)
+      : customDbUrl;
+    const customAnchor = createAnchor({
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'https://anchor.example.com' },
+      security: {
+        sep10SigningKey: sep10ServerKeypair.secret(),
+        interactiveJwtSecret: 'jwt-test-secret-rate-limit',
+        distributionAccountSecret: 'distribution-test-secret',
+      },
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+      framework: {
+        database: {
+          provider: 'sqlite',
+          url: customDbUrl,
+        },
+        rateLimit: {
+          windowMs: 60000,
+          authChallengeMax: 1,
+          authTokenMax: 5,
+          webhookMax: 20,
+          depositMax: 20,
+        },
+      },
+    });
+
+    try {
+      await customAnchor.init();
+      const customInvoke = createMountedInvoker(customAnchor);
+      const account = Keypair.random().publicKey();
+      const headers = { 'x-forwarded-for': '203.0.113.232' };
+
+      const firstResponse = await customInvoke({
+        path: `/auth/challenge?account=${account}`,
+        headers,
+      });
+      expect(firstResponse.status).toBe(200);
+
+      const limitedResponse = await customInvoke({
+        path: `/auth/challenge?account=${account}`,
+        headers,
+      });
+
+      expect(limitedResponse.status).toBe(429);
+      expect(limitedResponse.headers['retry-after']).toBeDefined();
+      expect(limitedResponse.body.error).toBe('rate_limited');
+      expect(limitedResponse.body.retry_after_seconds).toBe(
+        Number(limitedResponse.headers['retry-after']),
+      );
+    } finally {
+      await customAnchor.shutdown();
+      try {
+        unlinkSync(customDbPath);
+      } catch {
+        // ignore cleanup errors in CI
+      }
+    }
+  });
+
   it('3b) auth token with custom TTL returns correct expires_in', async () => {
     // Create a new anchor instance with custom TTL using a separate database
     const customDbUrl = makeSqliteDbUrlForTests();


### PR DESCRIPTION
## What changed
- Added `retry_after_seconds` to the JSON body returned for HTTP 429 rate-limit responses.
- Reused the exact `result.retryAfterSeconds` value already sent in the `Retry-After` response header.
- Added an integration test that triggers a 429 on `/auth/challenge` and asserts the body value matches the header.

## Scope notes
- No new runtime dependencies.
- Change is limited to the existing rate-limit response helper and focused integration coverage.

## Verification
- `bun test tests/mvp-express.integration.test.ts` passed: 34 tests
- `bun test tests/runtime-rate-limiter.test.ts` passed: 3 tests
- `bun test` passed: 321 tests
- `bun run build` passed
- `bun run lint` passed
- `bun run typecheck` passed
- `bun run format:check` passed
- `git diff --check` passed

Closes #232
