### PR TITLE
fix(test): resolve 404 test not catching the unknown parts

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -182,6 +182,12 @@ describe('MVP Express-mounted integration', () => {
     expect(response.body.status).toBe('ok');
   });
 
+  it('1b) unknown endpoint returns 404 not_found', async () => {
+    const response = await invoke({ path: '/does-not-exist' });
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'not_found', message: 'Endpoint not found' });
+  });
+
   it('2) /info returns configured assets and package version', async () => {
     const response = await invoke({ path: '/info' });
     expect(response.status).toBe(200);


### PR DESCRIPTION
## What does this PR do?

Adds integration coverage for unknown endpoints in the mounted router integration suite.

Specifically, it adds a new test in `tests/mvp-express.integration.test.ts` that hits an unmapped path and asserts the current not-found contract:
- status code: `404`
- body: `{ "error": "not_found", "message": "Endpoint not found" }`

No runtime behavior was changed; this PR only makes the existing 404 fallback explicit in tests.

## How to test?

- Run:
  - `bun test`
- Confirm the new test passes:
  - `MVP Express-mounted integration > 1b) unknown endpoint returns 404 not_found`

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #235