### PR TITLE
feat: validate networkPassphrase as non-empty string in NetworkConfig…

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -166,6 +166,11 @@ export const NetworkConfigSchema = {
     if (config.horizonUrl && !ValidationUtils.isValidUrl(config.horizonUrl)) {
       throw new Error('Invalid URL format for network.horizonUrl');
     }
+    if (config.networkPassphrase !== undefined && config.networkPassphrase !== null) {
+      if (typeof config.networkPassphrase !== 'string' || config.networkPassphrase.length === 0) {
+        throw new Error('Invalid network.networkPassphrase: must be a non-empty string');
+      }
+    }
   },
 };
 

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -142,6 +142,49 @@ describe('NetworkConfigSchema', () => {
       }),
     ).toThrow(/Invalid URL format/);
   });
+
+  test('should validate a correct NetworkConfig with networkPassphrase', () => {
+    expect(() =>
+      NetworkConfigSchema.validate({
+        network: 'testnet',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      }),
+    ).not.toThrow();
+  });
+
+  test('should throw for empty networkPassphrase', () => {
+    expect(() =>
+      NetworkConfigSchema.validate({
+        network: 'testnet',
+        networkPassphrase: '',
+      }),
+    ).toThrow(/non-empty string/);
+  });
+
+  test('should throw for non-string networkPassphrase', () => {
+    expect(() =>
+      // @ts-expect-error test case
+      NetworkConfigSchema.validate({
+        network: 'testnet',
+        networkPassphrase: 123,
+      }),
+    ).toThrow(/non-empty string/);
+  });
+
+  test('should accept undefined or null networkPassphrase', () => {
+    expect(() =>
+      NetworkConfigSchema.validate({
+        network: 'testnet',
+        networkPassphrase: undefined,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      NetworkConfigSchema.validate({
+        network: 'testnet',
+        networkPassphrase: null as unknown as string,
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe('SecurityConfigSchema', () => {

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -163,9 +163,9 @@ describe('NetworkConfigSchema', () => {
 
   test('should throw for non-string networkPassphrase', () => {
     expect(() =>
-      // @ts-expect-error test case
       NetworkConfigSchema.validate({
         network: 'testnet',
+        // @ts-expect-error testing non-string value
         networkPassphrase: 123,
       }),
     ).toThrow(/non-empty string/);


### PR DESCRIPTION
Description
This PR adds validation to the [NetworkConfigSchema](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ensure that when [networkPassphrase](vscode-file://vscode-app/c:/Users/PC/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is provided, it must be a non-empty string. This prevents anchors from starting with unusable signing configurations due to empty or invalid passphrases.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #255
