### PR TITLE
feat(http): add trustForwardedFor flag, rate limiter cleanup

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -90,6 +90,7 @@ export class AnchorConfig {
               authTokenMax: input.framework.rateLimit?.authTokenMax ?? 30,
               webhookMax: input.framework.rateLimit?.webhookMax ?? 120,
               depositMax: input.framework.rateLimit?.depositMax ?? 60,
+              trustForwardedFor: input.framework.rateLimit?.trustForwardedFor ?? false,
             },
           }
         : undefined,

--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -664,7 +664,7 @@ export class AnchorExpressRouter {
     res: ServerResponse,
     endpoint: 'auth_challenge' | 'auth_token' | 'webhook' | 'deposit',
   ): boolean {
-    const trustForwardedFor = this.config.get('framework').rateLimit?.trustForwardedFor ?? false;
+    const trustForwardedFor = this.config.get('framework')?.rateLimit?.trustForwardedFor ?? false;
     const clientId = extractClientIdentifier(req, trustForwardedFor);
     const key = `${endpoint}:${clientId}`;
     const result = this.rateLimiter.hit(key, this.rateRules[endpoint]);

--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -127,11 +127,14 @@ function endpointPath(req: IncomingMessage): string {
   return parseUrl(req).pathname;
 }
 
-function extractClientIdentifier(req: IncomingMessage): string {
-  const forwardedFor = req.headers['x-forwarded-for'];
-  const leftMost = typeof forwardedFor === 'string' ? forwardedFor.split(',')[0].trim() : null;
+function extractClientIdentifier(req: IncomingMessage, trustForwardedFor: boolean): string {
   const socketIp = req.socket?.remoteAddress;
-  return leftMost || socketIp || 'unknown';
+  if (trustForwardedFor) {
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const leftMost = typeof forwardedFor === 'string' ? forwardedFor.split(',')[0].trim() : null;
+    return leftMost || socketIp || 'unknown';
+  }
+  return socketIp || 'unknown';
 }
 
 function hasValidSignature(transaction: Transaction, publicKey: string): boolean {
@@ -661,7 +664,8 @@ export class AnchorExpressRouter {
     res: ServerResponse,
     endpoint: 'auth_challenge' | 'auth_token' | 'webhook' | 'deposit',
   ): boolean {
-    const clientId = extractClientIdentifier(req);
+    const trustForwardedFor = this.config.get('framework').rateLimit?.trustForwardedFor ?? false;
+    const clientId = extractClientIdentifier(req, trustForwardedFor);
     const key = `${endpoint}:${clientId}`;
     const result = this.rateLimiter.hit(key, this.rateRules[endpoint]);
 

--- a/src/runtime/http/rate-limiter.ts
+++ b/src/runtime/http/rate-limiter.ts
@@ -10,8 +10,23 @@ export interface RateLimitRule {
 
 export class InMemoryRateLimiter {
   private readonly buckets = new Map<string, RateLimitBucket>();
+  private lastCleanupAt: number = Date.now();
+  private readonly cleanupIntervalMs: number = 60000; // 1 minute
+
+  private cleanupExpiredBuckets(): void {
+    const now = Date.now();
+    if (now - this.lastCleanupAt > this.cleanupIntervalMs) {
+      for (const [key, bucket] of this.buckets) {
+        if (now >= bucket.resetAt) {
+          this.buckets.delete(key);
+        }
+      }
+      this.lastCleanupAt = now;
+    }
+  }
 
   public hit(key: string, rule: RateLimitRule): { allowed: boolean; retryAfterSeconds: number } {
+    this.cleanupExpiredBuckets();
     const now = Date.now();
     const bucket = this.buckets.get(key);
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -498,6 +498,13 @@ export interface FrameworkConfig {
      * @optional - defaults to 60
      */
     depositMax?: number;
+
+    /**
+     * Trust x-forwarded-for header for client IP identification.
+     * Only set this to true if you're behind a trusted proxy.
+     * @optional - defaults to false
+     */
+    trustForwardedFor?: boolean;
   };
 
   /**

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -142,6 +142,7 @@ describe('MVP Express-mounted integration', () => {
           authTokenMax: 5,
           webhookMax: 20,
           depositMax: 20,
+          trustForwardedFor: true,
         },
         queue: {
           backend: 'memory',


### PR DESCRIPTION
## What does this PR do?

1. No more trusting x-forwarded-for by default: Added a new config option framework.rateLimit.trustForwardedFor, which defaults to false. When enabled, it uses the leftmost IP from x-forwarded-for, and it uses the socket's remoteAddress.
2. Cleanup of expired buckets: The InMemoryRateLimiter now periodically (every minute) cleans up expired rate limit buckets to prevent unbounded memory growth.

## How to test?

run npx vitest run tests/runtime-rate-limiter.test.ts

## Checklist

- [ .] My code follows the code style of this project.
- [ .] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ .] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #206 
