### PR TITLE
test: add sqlite missing transaction lookup, watcher stop-before-star…

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -802,6 +802,26 @@ describe('MVP Express-mounted integration', () => {
     expect((response.body.event_id as string).length).toBeGreaterThan(0);
   });
 
+  it('8f) webhook route accepts an empty body and generates event_id for signed empty payloads', async () => {
+    const signature = createHmac('sha256', 'webhook-test-secret').update('').digest('hex');
+
+    const response = await invoke({
+      method: 'POST',
+      path: '/webhooks/events',
+      headers: {
+        'content-type': 'application/json',
+        'x-webhook-provider': 'generic',
+        'x-anchor-signature': signature,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.received).toBe(true);
+    expect(response.body.duplicate).toBe(false);
+    expect(typeof response.body.event_id).toBe('string');
+    expect((response.body.event_id as string).length).toBeGreaterThan(0);
+  });
+
   it('8e) webhook success response includes received_at ISO timestamp', async () => {
     const payload = {
       id: 'evt_received_at_check',

--- a/tests/runtime/sql-adapter-interactive-tx.test.ts
+++ b/tests/runtime/sql-adapter-interactive-tx.test.ts
@@ -65,4 +65,9 @@ describe('SqlDatabaseAdapter – interactive transaction status updates', () => 
       globalThis.Date = RealDate;
     }
   });
+
+  it('returns null for getInteractiveTransactionById when the transaction does not exist', async () => {
+    const fetched = await db.getInteractiveTransactionById(randomUUID());
+    expect(fetched).toBeNull();
+  });
 });

--- a/tests/runtime/transaction-watcher.unit.test.ts
+++ b/tests/runtime/transaction-watcher.unit.test.ts
@@ -64,6 +64,13 @@ describe('TransactionWatcher Unit Tests', () => {
     });
   });
 
+  it('treats stop() before start() as a safe no-op', async () => {
+    await expect(transactionWatcher.stop()).resolves.toBeUndefined();
+    expect(mockDatabase.listPendingTransactionsBefore).not.toHaveBeenCalled();
+    expect(mockQueue.enqueue).not.toHaveBeenCalled();
+    expect(mockQueue.stop).not.toHaveBeenCalled();
+  });
+
   it('enqueues expiration jobs for stale pending deposits', async () => {
     const staleTransaction = {
       id: 'stale-tx-1',


### PR DESCRIPTION
# PR Summary

Adds focused tests for three behaviors:
- sqlite-backed `getInteractiveTransactionById()` returns `null` for unknown transaction IDs
- `TransactionWatcher.stop()` before `start()` is a safe no-op
- webhook route accepts an empty request body and returns a generated `event_id`

## How to test

- Run `bun test tests/runtime/sql-adapter-interactive-tx.test.ts tests/runtime/transaction-watcher.unit.test.ts tests/mvp-express.integration.test.ts`
- Confirm all tests pass

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have run `bun test` locally.

## Issue Reference

Closes #243, 
Closes #240, 
Closes #245
