### PR TITLE
fix: add network_passphrase to /info response

### DIFF
--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -246,6 +246,7 @@ export class AnchorExpressRouter {
       const responseBody: Record<string, unknown> = {
         name: fullConfig.operational?.name ?? 'Anchor-Kit Anchor',
         network: fullConfig.network.network,
+        network_passphrase: this.networkPassphrase,
         assets: fullConfig.assets.assets,
         version,
       };

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -199,9 +199,7 @@ describe('MVP Express-mounted integration', () => {
     expect(typeof response.body.network_passphrase).toBe('string');
     expect((response.body.network_passphrase as string).length).toBeGreaterThan(0);
     // testnet network should resolve to the Stellar testnet passphrase
-    expect(response.body.network_passphrase).toBe(
-      'Test SDF Network ; September 2015',
-    );
+    expect(response.body.network_passphrase).toBe('Test SDF Network ; September 2015');
   });
 
   it('2b) /info includes support_email when configured', async () => {

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -193,6 +193,17 @@ describe('MVP Express-mounted integration', () => {
     expect(response.body.interactive_domain).toBe('https://anchor.example.com');
   });
 
+  it('2e) /info includes network_passphrase matching the configured network', async () => {
+    const response = await invoke({ path: '/info' });
+    expect(response.status).toBe(200);
+    expect(typeof response.body.network_passphrase).toBe('string');
+    expect((response.body.network_passphrase as string).length).toBeGreaterThan(0);
+    // testnet network should resolve to the Stellar testnet passphrase
+    expect(response.body.network_passphrase).toBe(
+      'Test SDF Network ; September 2015',
+    );
+  });
+
   it('2b) /info includes support_email when configured', async () => {
     const customDbUrl = makeSqliteDbUrlForTests();
     const customAnchor = createAnchor({


### PR DESCRIPTION
## Summary

Adds a `network_passphrase` field to the `GET /info` response so integrators have a single place to confirm which Stellar network the anchor is operating on.

## Changes

- **`src/runtime/http/express-router.ts`**: Added `network_passphrase` to the `/info` response body, populated from `this.networkPassphrase` (already resolved from config at router startup — no new runtime dependencies).
- **`tests/mvp-express.integration.test.ts`**: Added test `2e)` that asserts the field is present, is a non-empty string, and matches the configured testnet passphrase (`Test SDF Network ; September 2015`).

## Acceptance criteria

- [x] The `/info` response includes `network_passphrase`.
- [x] The value matches the passphrase the SDK uses for SEP-10 challenge transactions.

## Testing

```
bun test   # 321 pass, 0 fail
```

Closes #228