### PR TITLE
fix: include event_id in webhook error response

### DIFF
--- a/src/runtime/http/express-router.ts
+++ b/src/runtime/http/express-router.ts
@@ -648,6 +648,7 @@ export class AnchorExpressRouter {
         sendJson(res, 400, {
           error: 'webhook_error',
           message: 'Webhook processing failed',
+          event_id: eventId,
         });
       }
       return;

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -831,6 +831,69 @@ describe('MVP Express-mounted integration', () => {
     expect(Number.isNaN(parsed)).toBe(false);
   });
 
+  it('8f) failed webhook error response includes event_id', async () => {
+    const customDbUrl = makeSqliteDbUrlForTests();
+    const customAnchor = createAnchor({
+      network: { network: 'testnet' },
+      server: {},
+      security: {
+        sep10SigningKey: sep10ServerKeypair.secret(),
+        interactiveJwtSecret: 'jwt-test-secret-error-event-id',
+        distributionAccountSecret: 'distribution-test-secret',
+        webhookSecret: 'webhook-test-secret',
+        verifyWebhookSignatures: true,
+      },
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+      framework: {
+        database: { provider: 'sqlite', url: customDbUrl },
+      },
+      webhooks: {
+        onEvent: async () => {
+          throw new Error('simulated processing failure');
+        },
+      },
+    });
+
+    await customAnchor.init();
+    const customInvoke = createMountedInvoker(customAnchor);
+
+    const payload = { id: 'evt_err_1', type: 'deposit.completed' };
+    const signature = createHmac('sha256', 'webhook-test-secret')
+      .update(JSON.stringify(payload))
+      .digest('hex');
+
+    const response = await customInvoke({
+      method: 'POST',
+      path: '/webhooks/events',
+      headers: {
+        'content-type': 'application/json',
+        'x-anchor-signature': signature,
+      },
+      body: payload,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('webhook_error');
+    expect(response.body.event_id).toBe('evt_err_1');
+
+    await customAnchor.shutdown();
+    const customDbPath = customDbUrl.startsWith('file:')
+      ? customDbUrl.slice('file:'.length)
+      : customDbUrl;
+    try {
+      unlinkSync(customDbPath);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
   it('9) queue worker/watcher processes at least one watch task', async () => {
     await new Promise((resolve) => setTimeout(resolve, 125));
     const processed = await anchor.getProcessedWatcherTaskCount();


### PR DESCRIPTION
## Summary

When webhook processing fails, echoes the resolved `event_id` back in the 400 error body so integrators can correlate a failed webhook with their own event log.

## Changes

- **`src/runtime/http/express-router.ts`**: Added `event_id` to the `catch` block response in the `POST /webhooks/events` handler. The `eventId` variable is already resolved before the `try/catch`, so no logic changes are needed — only the error response body is extended.
- **`tests/mvp-express.integration.test.ts`**: Added test `8f)` that configures an `onEvent` callback that always throws, then asserts the 400 error response body contains `event_id` matching the sent payload `id`.

## Acceptance criteria

- [x] A failed webhook response includes `event_id` when one was resolved.
- [x] Successful webhook responses remain unchanged.
- [x] Status code remains 400 on failure.

## Testing

```
bun test   # 321 pass, 0 fail
```

Closes #244