### PR TITLE
Case sensitive

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -389,6 +389,19 @@ describe('MVP Express-mounted integration', () => {
     }
   });
 
+  it('3c) auth token rejects invalid account', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/auth/token',
+      headers: { 'content-type': 'application/json' },
+      body: { account: 'not-a-stellar-key', challenge: 'some-challenge' },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.message).toBe('account must be a valid Stellar public key');
+  });
+
   it('4) unauthorized deposit interactive rejected', async () => {
     const response = await invoke({
       method: 'POST',

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -393,7 +393,10 @@ describe('MVP Express-mounted integration', () => {
     const response = await invoke({
       method: 'POST',
       path: '/auth/token',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '10.0.0.5',
+      },
       body: { account: 'not-a-stellar-key', challenge: 'some-challenge' },
     });
 

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -462,6 +462,22 @@ describe('MVP Express-mounted integration', () => {
     expect(response.body.id).toBeUndefined();
   });
 
+  it('5f) deposit with differently-cased asset_code is rejected', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/transactions/deposit/interactive',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${accessToken}`,
+      },
+      body: { asset_code: 'usdc', amount: '10' }, // configured as USDC
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_asset');
+    expect(response.body.id).toBeUndefined();
+  });
+
   it('5e) deposit with deposits_enabled: false asset is rejected', async () => {
     const disabledDbUrl = makeSqliteDbUrlForTests();
     const disabledAnchor = createAnchor({


### PR DESCRIPTION
- closes #226

Summary This PR adds integration test coverage to ensure that asset code lookups during the deposit process are case-sensitive.

Changes

- Added test case 5f to mvp-express.integration.test.ts which attempts a deposit with a lowercase asset_code when an uppercase one is configured.
- Verified that the response is a 400 Bad Request with invalid_asset .
Testing

- Ran the full integration suite via bun test and confirmed all tests passed.