### PR TITLE
fix(validation): reject asset config when min_amount exceeds max_amount

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -121,6 +121,15 @@ export const AssetSchema = {
     if (a.min_amount !== undefined && typeof a.min_amount !== 'number') return false;
     if (a.max_amount !== undefined && typeof a.max_amount !== 'number') return false;
 
+    // Relationship check: min_amount must not exceed max_amount when both are present
+    if (
+      typeof a.min_amount === 'number' &&
+      typeof a.max_amount === 'number' &&
+      a.min_amount > a.max_amount
+    ) {
+      return false;
+    }
+
     return true;
   },
 };

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -129,7 +129,6 @@ export const AssetSchema = {
     ) {
       return false;
     }
-
     return true;
   },
 };

--- a/tests/verify-exports.test.ts
+++ b/tests/verify-exports.test.ts
@@ -94,4 +94,51 @@ describe('AssetSchema Validation', () => {
     };
     expect(AssetSchema.isValid(invalidAsset)).toBe(false);
   });
+
+  // min_amount / max_amount relationship checks
+  it('should reject an asset where min_amount exceeds max_amount', () => {
+    const invalidAsset = {
+      code: 'USDC',
+      issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+      min_amount: 1000,
+      max_amount: 100,
+    };
+    expect(AssetSchema.isValid(invalidAsset)).toBe(false);
+  });
+
+  it('should accept an asset where min_amount equals max_amount', () => {
+    const validAsset = {
+      code: 'USDC',
+      issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+      min_amount: 500,
+      max_amount: 500,
+    };
+    expect(AssetSchema.isValid(validAsset)).toBe(true);
+  });
+
+  it('should accept an asset with only min_amount', () => {
+    const validAsset = {
+      code: 'USDC',
+      issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+      min_amount: 10,
+    };
+    expect(AssetSchema.isValid(validAsset)).toBe(true);
+  });
+
+  it('should accept an asset with only max_amount', () => {
+    const validAsset = {
+      code: 'USDC',
+      issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+      max_amount: 5000,
+    };
+    expect(AssetSchema.isValid(validAsset)).toBe(true);
+  });
+
+  it('should accept an asset with neither min_amount nor max_amount', () => {
+    const validAsset = {
+      code: 'USDC',
+      issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    };
+    expect(AssetSchema.isValid(validAsset)).toBe(true);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Please provide a brief description of the changes in this PR.
Adds a relationship check to AssetSchema.isValid so that when both min_amount and max_amount are provided on an asset, min_amount must not exceed max_amount. The existing type checks and single-bound cases are unchanged.
## How to test?

Please describe how to verify the changes.
Run the following command
bun run test

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #39