### PR TITLE
[246] Add integration test for webhook verification enabled without configured secret

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -744,6 +744,99 @@ describe('MVP Express-mounted integration', () => {
     }
   });
 
+  it('8c) webhook is rejected when verification is enabled without configured secret', async () => {
+    const customDbUrl = makeSqliteDbUrlForTests();
+    let misconfiguredWebhookCallbackCount = 0;
+
+    const customAnchor = createAnchor({
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'https://anchor.example.com' },
+      security: {
+        sep10SigningKey: sep10ServerKeypair.secret(),
+        interactiveJwtSecret: 'jwt-test-secret-webhook-misconfigured',
+        distributionAccountSecret: 'distribution-test-secret',
+        verifyWebhookSignatures: true,
+      },
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+            deposits_enabled: true,
+          },
+        ],
+      },
+      framework: {
+        database: {
+          provider: 'sqlite',
+          url: customDbUrl,
+        },
+      },
+      webhooks: {
+        onEvent: async () => {
+          misconfiguredWebhookCallbackCount += 1;
+        },
+      },
+    });
+
+    await customAnchor.init();
+    const customInvoke = createMountedInvoker(customAnchor);
+
+    const payload = {
+      id: 'evt_misconfigured',
+      type: 'deposit.completed',
+      transaction_id: 'tx_misconfigured',
+    };
+
+    const unsignedResponse = await customInvoke({
+      method: 'POST',
+      path: '/webhooks/events',
+      headers: {
+        'content-type': 'application/json',
+        'x-webhook-provider': 'generic',
+      },
+      body: payload,
+    });
+
+    expect(unsignedResponse.status).toBe(400);
+    expect(unsignedResponse.body).toEqual({
+      error: 'webhook_error',
+      message: 'Webhook processing failed',
+    });
+
+    const signature = createHmac('sha256', 'any-secret')
+      .update(JSON.stringify(payload))
+      .digest('hex');
+
+    const signedResponse = await customInvoke({
+      method: 'POST',
+      path: '/webhooks/events',
+      headers: {
+        'content-type': 'application/json',
+        'x-webhook-provider': 'generic',
+        'x-anchor-signature': signature,
+      },
+      body: payload,
+    });
+
+    expect(signedResponse.status).toBe(400);
+    expect(signedResponse.body).toEqual({
+      error: 'webhook_error',
+      message: 'Webhook processing failed',
+    });
+    expect(misconfiguredWebhookCallbackCount).toBe(0);
+
+    await customAnchor.shutdown();
+    const customDbPath = customDbUrl.startsWith('file:')
+      ? customDbUrl.slice('file:'.length)
+      : customDbUrl;
+    try {
+      unlinkSync(customDbPath);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
   it('8b) webhook route uses default provider when no header provided', async () => {
     const payload = {
       id: 'evt_2',


### PR DESCRIPTION
## Summary
- Add integration coverage for an anchor configured with `verifyWebhookSignatures: true` and no `webhookSecret`.
- Assert both unsigned and signed webhook requests are rejected with the current `webhook_error` response.

## Test plan
- [x] `bun test tests/mvp-express.integration.test.ts -t "8c"`
- [x] `bun test` (full suite)

Closes #246
