### PR TITLE
test: add DefaultWebhookProcessor signature verification unit tests

### DIFF
--- a/tests/runtime/webhooks/default-webhook-processor.test.ts
+++ b/tests/runtime/webhooks/default-webhook-processor.test.ts
@@ -126,7 +126,9 @@ describe('DefaultWebhookProcessor', () => {
         rawBody: '{}',
         signature: 'invalid-signature',
       }),
-    ).rejects.toThrow('Webhook signature verification is enabled but no webhook secret is configured');
+    ).rejects.toThrow(
+      'Webhook signature verification is enabled but no webhook secret is configured',
+    );
 
     expect(callbackInvokedCount).toBe(0);
   });

--- a/tests/runtime/webhooks/default-webhook-processor.test.ts
+++ b/tests/runtime/webhooks/default-webhook-processor.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { DefaultWebhookProcessor } from '../../../src/runtime/webhooks/default-webhook-processor.ts';
 import type { AnchorKitConfig } from '../../../src/types/config.ts';
 import type { DatabaseAdapter, WebhookEventRecord } from '../../../src/runtime/interfaces.ts';
@@ -91,5 +92,122 @@ describe('DefaultWebhookProcessor', () => {
     expect(result.duplicate).toBe(true);
     expect(result.eventId).toBe('evt_duplicate');
     expect(callbackInvokedCount).toBe(0);
+  });
+
+  test('throws when verification is enabled but webhook secret is missing', async () => {
+    const config: AnchorKitConfig = {
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'test.example.com' },
+      assets: { assets: [] },
+      framework: { database: { provider: 'sqlite', url: 'file::memory:' } },
+      security: {
+        sep10SigningKey: 'SCZJBZ6S7HWMQVT7DM74JVHVDKCEE5P6I6T3E5M7LJM6LJM6LJM6LJM6',
+        interactiveJwtSecret: 'test-jwt-secret',
+        distributionAccountSecret: 'test-distribution-secret',
+        verifyWebhookSignatures: true,
+      },
+      webhooks: {
+        onEvent: async () => {
+          callbackInvokedCount += 1;
+        },
+      },
+    };
+
+    const processorWithMissingSecret = new DefaultWebhookProcessor({
+      config,
+      database: mockDatabase as DatabaseAdapter,
+    });
+
+    await expect(
+      processorWithMissingSecret.process({
+        eventId: 'evt_missing_secret',
+        provider: 'test-provider',
+        payload: { type: 'test' },
+        rawBody: '{}',
+        signature: 'invalid-signature',
+      }),
+    ).rejects.toThrow('Webhook signature verification is enabled but no webhook secret is configured');
+
+    expect(callbackInvokedCount).toBe(0);
+  });
+
+  test('throws on invalid webhook signature and does not invoke callback', async () => {
+    const config: AnchorKitConfig = {
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'test.example.com' },
+      assets: { assets: [] },
+      framework: { database: { provider: 'sqlite', url: 'file::memory:' } },
+      security: {
+        sep10SigningKey: 'SCZJBZ6S7HWMQVT7DM74JVHVDKCEE5P6I6T3E5M7LJM6LJM6LJM6LJM6',
+        interactiveJwtSecret: 'test-jwt-secret',
+        distributionAccountSecret: 'test-distribution-secret',
+        verifyWebhookSignatures: true,
+        webhookSecret: 'webhook-test-secret',
+      },
+      webhooks: {
+        onEvent: async () => {
+          callbackInvokedCount += 1;
+        },
+      },
+    };
+
+    const secureProcessor = new DefaultWebhookProcessor({
+      config,
+      database: mockDatabase as DatabaseAdapter,
+    });
+
+    await expect(
+      secureProcessor.process({
+        eventId: 'evt_invalid_signature',
+        provider: 'test-provider',
+        payload: { type: 'test' },
+        rawBody: '{}',
+        signature: 'invalid-signature',
+      }),
+    ).rejects.toThrow('Invalid webhook signature');
+
+    expect(callbackInvokedCount).toBe(0);
+  });
+
+  test('accepts a valid webhook signature and invokes callback', async () => {
+    const webhookSecret = 'webhook-test-secret';
+    const rawBody = '{"type":"test"}';
+    const validSignature = createHmac('sha256', webhookSecret).update(rawBody).digest('hex');
+
+    const config: AnchorKitConfig = {
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'test.example.com' },
+      assets: { assets: [] },
+      framework: { database: { provider: 'sqlite', url: 'file::memory:' } },
+      security: {
+        sep10SigningKey: 'SCZJBZ6S7HWMQVT7DM74JVHVDKCEE5P6I6T3E5M7LJM6LJM6LJM6LJM6',
+        interactiveJwtSecret: 'test-jwt-secret',
+        distributionAccountSecret: 'test-distribution-secret',
+        verifyWebhookSignatures: true,
+        webhookSecret,
+      },
+      webhooks: {
+        onEvent: async () => {
+          callbackInvokedCount += 1;
+        },
+      },
+    };
+
+    const secureProcessor = new DefaultWebhookProcessor({
+      config,
+      database: mockDatabase as DatabaseAdapter,
+    });
+
+    const result = await secureProcessor.process({
+      eventId: 'evt_valid_signature',
+      provider: 'test-provider',
+      payload: { type: 'test' },
+      rawBody,
+      signature: validSignature,
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(result.eventId).toBe('evt_valid_signature');
+    expect(callbackInvokedCount).toBe(1);
   });
 });


### PR DESCRIPTION
# PR Description

## What does this PR do?

Adds focused unit tests for `DefaultWebhookProcessor` signature verification.

- Covers the case where webhook signature verification is enabled but no secret is configured.
- Covers invalid signature rejection and ensures the callback is not invoked.
- Covers valid signature acceptance and ensures the callback is invoked.

## How to test?

1. Run the focused test file:
   - `bun test tests/runtime/webhooks/default-webhook-processor.test.ts`
2. Optionally run the full test suite if dependencies are installed:
   - `bun test`

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #247
Closes #248
Closes #249
