### PR TITLE
test(transaction-watcher): add unit test for start() called twice

### DIFF
--- a/tests/runtime/transaction-watcher.unit.test.ts
+++ b/tests/runtime/transaction-watcher.unit.test.ts
@@ -232,4 +232,24 @@ describe('TransactionWatcher Unit Tests', () => {
     // Stop the watcher
     await customWatcher.stop();
   });
+
+  it('does not create additional polling timer when start() is called twice', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    await transactionWatcher.start();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    // Clear calls so the second start() doesn't count the first interval
+    setIntervalSpy.mockClear();
+
+    await transactionWatcher.start();
+    // The second start() should NOT create another timer
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    // The tick should still only have been executed once
+    expect(mockDatabase.listPendingTransactionsBefore).toHaveBeenCalledTimes(1);
+
+    setIntervalSpy.mockRestore();
+    await transactionWatcher.stop();
+  });
 });

--- a/tests/runtime/transaction-watcher.unit.test.ts
+++ b/tests/runtime/transaction-watcher.unit.test.ts
@@ -236,20 +236,19 @@ describe('TransactionWatcher Unit Tests', () => {
   it('does not create additional polling timer when start() is called twice', async () => {
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
 
-    await transactionWatcher.start();
-    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    try {
+      await transactionWatcher.start();
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
 
-    // Clear calls so the second start() doesn't count the first interval
-    setIntervalSpy.mockClear();
+      setIntervalSpy.mockClear();
 
-    await transactionWatcher.start();
-    // The second start() should NOT create another timer
-    expect(setIntervalSpy).not.toHaveBeenCalled();
+      await transactionWatcher.start();
+      expect(setIntervalSpy).not.toHaveBeenCalled();
 
-    // The tick should still only have been executed once
-    expect(mockDatabase.listPendingTransactionsBefore).toHaveBeenCalledTimes(1);
-
-    setIntervalSpy.mockRestore();
-    await transactionWatcher.stop();
+      expect(mockDatabase.listPendingTransactionsBefore).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+      await transactionWatcher.stop();
+    }
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds a unit test for `TransactionWatcher.start()` called twice (#239). The test mocks the database and queue, calls `start()` twice, and asserts that only one polling timer is created and the tick logic does not double-execute.

## How to test?

```bash
bun test tests/runtime/transaction-watcher.unit.test.ts
```
Look for the test named "does not create additional polling timer when start() is called twice".

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #239 
