### PR TITLE
validate transactionTimeoutMs and retentionDays in AnchorKitConfigSchema

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -256,6 +256,22 @@ export const AnchorKitConfigSchema = {
     ) {
       throw new Error('framework.watchers.pollIntervalMs must be >= 10');
     }
+    if (
+      framework.watchers?.transactionTimeoutMs !== undefined &&
+      (typeof framework.watchers.transactionTimeoutMs !== 'number' ||
+        !isFinite(framework.watchers.transactionTimeoutMs) ||
+        framework.watchers.transactionTimeoutMs <= 0)
+    ) {
+      throw new Error('framework.watchers.transactionTimeoutMs must be a finite number > 0');
+    }
+    if (
+      framework.watchers?.retentionDays !== undefined &&
+      (typeof framework.watchers.retentionDays !== 'number' ||
+        !isFinite(framework.watchers.retentionDays) ||
+        framework.watchers.retentionDays <= 0)
+    ) {
+      throw new Error('framework.watchers.retentionDays must be a finite number > 0');
+    }
     if (framework.http?.maxBodyBytes !== undefined && framework.http.maxBodyBytes < 1024) {
       throw new Error('framework.http.maxBodyBytes must be >= 1024');
     }

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -222,4 +222,68 @@ describe('AnchorKitConfigSchema', () => {
     };
     expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/pollIntervalMs/);
   });
+
+  test('should throw for non-positive transactionTimeoutMs', () => {
+    const invalidConfig = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { transactionTimeoutMs: 0 } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/transactionTimeoutMs/);
+  });
+
+  test('should throw for negative transactionTimeoutMs', () => {
+    const invalidConfig = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { transactionTimeoutMs: -1 } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/transactionTimeoutMs/);
+  });
+
+  test('should throw for non-finite transactionTimeoutMs', () => {
+    const invalidConfig = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { transactionTimeoutMs: Infinity } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/transactionTimeoutMs/);
+  });
+
+  test('should accept valid transactionTimeoutMs', () => {
+    const cfg = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { transactionTimeoutMs: 300000 } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(cfg)).not.toThrow();
+  });
+
+  test('should throw for non-positive retentionDays', () => {
+    const invalidConfig = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { retentionDays: 0 } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/retentionDays/);
+  });
+
+  test('should throw for negative retentionDays', () => {
+    const invalidConfig = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { retentionDays: -5 } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/retentionDays/);
+  });
+
+  test('should throw for non-finite retentionDays', () => {
+    const invalidConfig = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { retentionDays: NaN } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(invalidConfig)).toThrow(/retentionDays/);
+  });
+
+  test('should accept valid retentionDays', () => {
+    const cfg = {
+      ...validConfig,
+      framework: { ...validConfig.framework, watchers: { retentionDays: 90 } },
+    };
+    expect(() => AnchorKitConfigSchema.validate(cfg)).not.toThrow();
+  });
 });


### PR DESCRIPTION
Closes #251

## Summary

Extends `AnchorKitConfigSchema.validate` to reject invalid values for the two previously unchecked watcher numeric fields.

## Changes

**`src/utils/validation.ts`**
- Added validation for `framework.watchers.transactionTimeoutMs`: must be a finite number > 0
- Added validation for `framework.watchers.retentionDays`: must be a finite number > 0
- Existing `pollIntervalMs` validation is untouched

**`tests/utils/validation.test.ts`**
- 8 new focused tests covering zero, negative, `Infinity`, `NaN`, and valid inputs for both fields

## Testing

```
bun test   # 328 pass, 0 fail
```