### PR TITLE
Add MAX_BODY_BYTES support to the example app

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -23,6 +23,7 @@ Server starts on `http://localhost:3000` by default.
 - `DATABASE_URL`: overrides the example database location
 - `CHALLENGE_EXPIRATION_SECONDS`: overrides the SEP-10 challenge lifetime in seconds. Defaults to `300`.
 - `WATCHERS_ENABLED`: set to `false` to disable background watchers. Defaults to enabled.
+- `MAX_BODY_BYTES`: overrides the request body byte limit exposed by the SDK through `framework.http.maxBodyBytes`. Must be at least `1024`. Defaults to `1048576` (1 MiB).
 
 ## Quick check
 

--- a/example/express-app.ts
+++ b/example/express-app.ts
@@ -28,6 +28,28 @@ function getWatchersEnabled(): boolean {
   return process.env.WATCHERS_ENABLED !== 'false';
 }
 
+/**
+ * SDK default request body byte limit, kept in sync with the core config
+ * default so the example matches the out-of-the-box behaviour when the env var
+ * is not provided.
+ */
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+
+function getMaxBodyBytes(): number {
+  const rawValue = process.env.MAX_BODY_BYTES;
+
+  if (!rawValue) {
+    return DEFAULT_MAX_BODY_BYTES;
+  }
+
+  const parsedValue = Number(rawValue);
+  if (!Number.isFinite(parsedValue) || parsedValue < 1024) {
+    return DEFAULT_MAX_BODY_BYTES;
+  }
+
+  return parsedValue;
+}
+
 export async function createExampleApp(): Promise<ExampleApp> {
   const databaseUrl =
     process.env.DATABASE_URL ?? `file:/tmp/anchor-kit-example-${randomUUID()}.sqlite`;
@@ -61,6 +83,9 @@ export async function createExampleApp(): Promise<ExampleApp> {
       database: {
         provider: databaseUrl.startsWith('file:') ? 'sqlite' : 'postgres',
         url: databaseUrl,
+      },
+      http: {
+        maxBodyBytes: getMaxBodyBytes(),
       },
       queue: {
         backend: 'memory',

--- a/tests/example-express-app.test.ts
+++ b/tests/example-express-app.test.ts
@@ -14,6 +14,9 @@ interface ExampleAppRuntime {
   anchor: {
     config: {
       get: (key: 'framework') => {
+        http?: {
+          maxBodyBytes?: number;
+        };
         watchers?: {
           enabled?: boolean;
         };
@@ -120,6 +123,7 @@ async function createExampleAppHarness(
   options: {
     challengeExpirationSeconds?: string;
     watchersEnabled?: string;
+    maxBodyBytes?: string;
   } = {},
 ): Promise<ExampleAppHarness> {
   const sep10ServerKeypair = Keypair.random();
@@ -128,11 +132,13 @@ async function createExampleAppHarness(
   const originalSep10SigningKey = process.env.SEP10_SIGNING_KEY;
   const originalChallengeExpirationSeconds = process.env.CHALLENGE_EXPIRATION_SECONDS;
   const originalWatchersEnabled = process.env.WATCHERS_ENABLED;
+  const originalMaxBodyBytes = process.env.MAX_BODY_BYTES;
 
   setOptionalEnvVar('DATABASE_URL', `file:${dbPath}`);
   setOptionalEnvVar('SEP10_SIGNING_KEY', sep10ServerKeypair.secret());
   setOptionalEnvVar('CHALLENGE_EXPIRATION_SECONDS', options.challengeExpirationSeconds);
   setOptionalEnvVar('WATCHERS_ENABLED', options.watchersEnabled);
+  setOptionalEnvVar('MAX_BODY_BYTES', options.maxBodyBytes);
 
   const runtime = await createExampleApp();
 
@@ -145,6 +151,7 @@ async function createExampleAppHarness(
       setOptionalEnvVar('SEP10_SIGNING_KEY', originalSep10SigningKey);
       setOptionalEnvVar('CHALLENGE_EXPIRATION_SECONDS', originalChallengeExpirationSeconds);
       setOptionalEnvVar('WATCHERS_ENABLED', originalWatchersEnabled);
+      setOptionalEnvVar('MAX_BODY_BYTES', originalMaxBodyBytes);
       removeFileIfPresent(dbPath);
     },
   };
@@ -214,6 +221,10 @@ describe('example/express-app', () => {
   it('keeps watchers enabled when the env var is absent', () => {
     expect(harness.runtime.anchor.config.get('framework').watchers?.enabled).toBe(true);
   });
+
+  it('uses the default max body bytes when the env var is absent', () => {
+    expect(harness.runtime.anchor.config.get('framework').http?.maxBodyBytes).toBe(1024 * 1024);
+  });
 });
 
 describe('example/express-app CHALLENGE_EXPIRATION_SECONDS', () => {
@@ -257,5 +268,21 @@ describe('example/express-app WATCHERS_ENABLED', () => {
 
   it('disables watchers when configured through the environment', () => {
     expect(harness.runtime.anchor.config.get('framework').watchers?.enabled).toBe(false);
+  });
+});
+
+describe('example/express-app MAX_BODY_BYTES', () => {
+  let harness: ExampleAppHarness;
+
+  beforeAll(async () => {
+    harness = await createExampleAppHarness({ maxBodyBytes: '2048' });
+  });
+
+  afterAll(async () => {
+    await harness.cleanup();
+  });
+
+  it('uses the configured max body bytes from the environment', () => {
+    expect(harness.runtime.anchor.config.get('framework').http?.maxBodyBytes).toBe(2048);
   });
 });


### PR DESCRIPTION
Exposes the SDK `framework.http.maxBodyBytes` setting via a `MAX_BODY_BYTES` env var in the example app, preserving the default (1 MiB) when unset. Closes #275