### PR TITLE
Add AUTH_TOKEN_LIFETIME_SECONDS support to the example app

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -22,6 +22,7 @@ Server starts on `http://localhost:3000` by default.
 
 - `DATABASE_URL`: overrides the example database location
 - `CHALLENGE_EXPIRATION_SECONDS`: overrides the SEP-10 challenge lifetime in seconds. Defaults to `300`.
+- `AUTH_TOKEN_LIFETIME_SECONDS`: overrides the access token lifetime in seconds exposed by the SDK through `security.authTokenLifetimeSeconds`. Must be greater than `0`. Defaults to `3600`.
 - `WATCHERS_ENABLED`: set to `false` to disable background watchers. Defaults to enabled.
 
 ## Quick check

--- a/example/express-app.ts
+++ b/example/express-app.ts
@@ -28,6 +28,28 @@ function getWatchersEnabled(): boolean {
   return process.env.WATCHERS_ENABLED !== 'false';
 }
 
+/**
+ * SDK default auth token lifetime in seconds, kept in sync with the core
+ * router default so the example matches the out-of-the-box behaviour when the
+ * env var is not provided.
+ */
+const DEFAULT_AUTH_TOKEN_LIFETIME_SECONDS = 3600;
+
+function getAuthTokenLifetimeSeconds(): number {
+  const rawValue = process.env.AUTH_TOKEN_LIFETIME_SECONDS;
+
+  if (!rawValue) {
+    return DEFAULT_AUTH_TOKEN_LIFETIME_SECONDS;
+  }
+
+  const parsedValue = Number(rawValue);
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    return DEFAULT_AUTH_TOKEN_LIFETIME_SECONDS;
+  }
+
+  return parsedValue;
+}
+
 export async function createExampleApp(): Promise<ExampleApp> {
   const databaseUrl =
     process.env.DATABASE_URL ?? `file:/tmp/anchor-kit-example-${randomUUID()}.sqlite`;
@@ -46,6 +68,7 @@ export async function createExampleApp(): Promise<ExampleApp> {
       webhookSecret: process.env.WEBHOOK_SECRET,
       verifyWebhookSignatures: process.env.WEBHOOK_SECRET ? true : false,
       challengeExpirationSeconds: getChallengeExpirationSeconds(),
+      authTokenLifetimeSeconds: getAuthTokenLifetimeSeconds(),
     },
     assets: {
       assets: [

--- a/tests/example-express-app.test.ts
+++ b/tests/example-express-app.test.ts
@@ -18,6 +18,9 @@ interface ExampleAppRuntime {
           enabled?: boolean;
         };
       };
+      get: (key: 'security') => {
+        authTokenLifetimeSeconds?: number;
+      };
     };
   };
   shutdown: () => Promise<void>;
@@ -120,6 +123,7 @@ async function createExampleAppHarness(
   options: {
     challengeExpirationSeconds?: string;
     watchersEnabled?: string;
+    authTokenLifetimeSeconds?: string;
   } = {},
 ): Promise<ExampleAppHarness> {
   const sep10ServerKeypair = Keypair.random();
@@ -128,11 +132,13 @@ async function createExampleAppHarness(
   const originalSep10SigningKey = process.env.SEP10_SIGNING_KEY;
   const originalChallengeExpirationSeconds = process.env.CHALLENGE_EXPIRATION_SECONDS;
   const originalWatchersEnabled = process.env.WATCHERS_ENABLED;
+  const originalAuthTokenLifetimeSeconds = process.env.AUTH_TOKEN_LIFETIME_SECONDS;
 
   setOptionalEnvVar('DATABASE_URL', `file:${dbPath}`);
   setOptionalEnvVar('SEP10_SIGNING_KEY', sep10ServerKeypair.secret());
   setOptionalEnvVar('CHALLENGE_EXPIRATION_SECONDS', options.challengeExpirationSeconds);
   setOptionalEnvVar('WATCHERS_ENABLED', options.watchersEnabled);
+  setOptionalEnvVar('AUTH_TOKEN_LIFETIME_SECONDS', options.authTokenLifetimeSeconds);
 
   const runtime = await createExampleApp();
 
@@ -145,6 +151,7 @@ async function createExampleAppHarness(
       setOptionalEnvVar('SEP10_SIGNING_KEY', originalSep10SigningKey);
       setOptionalEnvVar('CHALLENGE_EXPIRATION_SECONDS', originalChallengeExpirationSeconds);
       setOptionalEnvVar('WATCHERS_ENABLED', originalWatchersEnabled);
+      setOptionalEnvVar('AUTH_TOKEN_LIFETIME_SECONDS', originalAuthTokenLifetimeSeconds);
       removeFileIfPresent(dbPath);
     },
   };
@@ -214,6 +221,10 @@ describe('example/express-app', () => {
   it('keeps watchers enabled when the env var is absent', () => {
     expect(harness.runtime.anchor.config.get('framework').watchers?.enabled).toBe(true);
   });
+
+  it('uses the default auth token lifetime when the env var is absent', () => {
+    expect(harness.runtime.anchor.config.get('security').authTokenLifetimeSeconds).toBe(3600);
+  });
 });
 
 describe('example/express-app CHALLENGE_EXPIRATION_SECONDS', () => {
@@ -257,5 +268,21 @@ describe('example/express-app WATCHERS_ENABLED', () => {
 
   it('disables watchers when configured through the environment', () => {
     expect(harness.runtime.anchor.config.get('framework').watchers?.enabled).toBe(false);
+  });
+});
+
+describe('example/express-app AUTH_TOKEN_LIFETIME_SECONDS', () => {
+  let harness: ExampleAppHarness;
+
+  beforeAll(async () => {
+    harness = await createExampleAppHarness({ authTokenLifetimeSeconds: '15' });
+  });
+
+  afterAll(async () => {
+    await harness.cleanup();
+  });
+
+  it('uses the configured auth token lifetime from the environment', () => {
+    expect(harness.runtime.anchor.config.get('security').authTokenLifetimeSeconds).toBe(15);
   });
 });


### PR DESCRIPTION
Exposes the SDK `security.authTokenLifetimeSeconds` setting via an `AUTH_TOKEN_LIFETIME_SECONDS` env var in the example app, preserving the default (3600s) when unset. Closes #274