### PR TITLE
test: assert jobs enqueued after stop() are not processed

### DIFF
--- a/tests/runtime/queue.unit.test.ts
+++ b/tests/runtime/queue.unit.test.ts
@@ -288,6 +288,27 @@ describe('InMemoryQueueAdapter', () => {
     expect(startedJobs.length).toBeLessThanOrEqual(2);
   });
 
+  it('should not process jobs enqueued after stop()', async () => {
+    const queue = new InMemoryQueueAdapter({ concurrency: 1 });
+    const processedJobs: number[] = [];
+
+    const worker = async (job: QueueJob): Promise<void> => {
+      processedJobs.push(job.payload.jobId as number);
+    };
+
+    await queue.start(worker);
+    await queue.stop();
+
+    await queue.enqueue({
+      type: 'process_watcher_task',
+      payload: { jobId: 99 },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(processedJobs).toEqual([]);
+  });
+
   it('should resolve stop() only after the very last job is completely finished', async () => {
     const queue = new InMemoryQueueAdapter({ concurrency: 1 });
     let jobFinished = false;


### PR DESCRIPTION
Closes #237
- Adds a focused unit test for `InMemoryQueueAdapter` covering jobs enqueued after `stop()`.
- Asserts that post-shutdown enqueues are stored but never executed by the worker.
- Closes #237.
