### PR TITLE
Add README curl example for GET /info

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ Mounted under your chosen base path (for example `/anchor`):
 - `GET /transactions/:id` (Bearer auth)
 - `POST /webhooks/events`
 
+### `GET /info`
+
+```bash
+curl -s http://localhost:3000/anchor/info | jq
+```
+
+Returns the anchor's advertised config, including `name`, `network`, supported `assets`, and the SDK `version`.
+
 ## Docs
 
 - [Architecture Overview](./ARCHITECTURE.md)


### PR DESCRIPTION
Adds a simple  curl example to the README, grounded in the current endpoint and response shape. Closes #270