### PR TITLE
Add README curl example for webhook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ curl -s \
   "http://localhost:3000/anchor/transactions/${TX_ID}"
 ```
 
+### Webhook events
+
+Post a webhook event to `/webhooks/events`. When signature verification is enabled, send the raw body exactly as authored and pass its HMAC-SHA256 signature in `x-anchor-signature`; set the provider in `x-webhook-provider`.
+
+```bash
+WEBHOOK_SECRET="your-configured-webhook-secret"
+BODY='{"id":"evt_123456","provider":"flutterwave","event":"deposit.completed","amount":"25"}'
+
+SIGNATURE=$(printf '%s' "${BODY}" | openssl dgst -sha256 -hmac "${WEBHOOK_SECRET}" -hex | awk '{print $NF}')
+
+curl -s \
+  -X POST http://localhost:3000/anchor/webhooks/events \
+  -H 'content-type: application/json' \
+  -H "x-webhook-provider: flutterwave" \
+  -H "x-anchor-signature: ${SIGNATURE}" \
+  -d "${BODY}"
+```
+
 ## Docs
 
 - [Architecture Overview](./ARCHITECTURE.md)

--- a/tests/readme-webhook-curl.test.ts
+++ b/tests/readme-webhook-curl.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('README webhook curl example', () => {
+  it('documents a curl example for posting webhook events', () => {
+    const readmePath = new URL('../README.md', import.meta.url);
+    const readme = readFileSync(readmePath, 'utf8');
+
+    expect(readme).toContain('POST http://localhost:3000/anchor/webhooks/events');
+    expect(readme).toContain('x-webhook-provider');
+    expect(readme).toContain('x-anchor-signature');
+    expect(readme).toContain('openssl dgst -sha256 -hmac');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a README curl example that posts a webhook event to `POST /webhooks/events`, including the `x-webhook-provider` and `x-anchor-signature` (HMAC-SHA256 over the raw body) headers used by the current SDK.

## How to test?

`bun run test` — new `README webhook curl example` suite asserts the example and header names are present.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #269
