### PR TITLE
Add README curl example for /info

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ Mounted under your chosen base path (for example `/anchor`):
 
 Assume your host app mounts the router at `/anchor` on `http://localhost:3000`.
 
+### Advertised anchor info
+
+Get the anchor's advertised config (network, passphrase, supported assets, version):
+
+```bash
+curl -s http://localhost:3000/anchor/info
+```
+
 ### SEP-10 challenge/token flow
 
 Get a challenge for a Stellar account:

--- a/tests/readme-info-curl.test.ts
+++ b/tests/readme-info-curl.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('README /info curl example', () => {
+  it('documents a curl example for GET /info', () => {
+    const readmePath = new URL('../README.md', import.meta.url);
+    const readme = readFileSync(readmePath, 'utf8');
+
+    expect(readme).toContain('curl -s http://localhost:3000/anchor/info');
+    expect(readme).toContain('GET /info');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a README curl example for `GET /info` showing how to inspect the anchor's advertised config (network, passphrase, supported assets, version).

## How to test?

`bun run test` — new `README /info curl example` suite asserts the example is present.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #270
