### PR TITLE
Document all supported environment variables in the example app README

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -22,20 +22,20 @@ Server starts on `http://localhost:3000` by default.
 
 All variables are optional. When unset the listed default applies.
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `PORT` | `3000` | Port the example server listens on. Must be a positive number. |
-| `DATABASE_URL` | `file:/tmp/anchor-kit-example-<uuid>.sqlite` | Database location. `file:...` selects SQLite; otherwise PostgreSQL. |
-| `INTERACTIVE_DOMAIN` | `http://localhost:3000` | Interactive flow domain used by SEP-24. |
-| `SEP10_SIGNING_KEY` | fresh random keypair | SEP-10 challenge signing secret. Regenerated on every start unset. |
-| `INTERACTIVE_JWT_SECRET` | `example-jwt-secret` | Secret for SEP-24 interactive JWT tokens. |
-| `DISTRIBUTION_ACCOUNT_SECRET` | `example-distribution-secret` | Distribution account secret key. |
-| `WEBHOOK_SECRET` | unset | Webhook signing secret. When set, webhook signature verification is enabled. |
-| `CHALLENGE_EXPIRATION_SECONDS` | `300` | SEP-10 challenge lifetime in seconds. Falls back to default on invalid/non-positive values. |
-| `ASSET_CODE` | `USDC` | Code for the example supported asset. |
-| `ASSET_ISSUER` | `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` | Issuer for the example supported asset. |
-| `WATCHERS_ENABLED` | enabled | Set to `false` to disable background watchers. |
-| `DEBUG_WEBHOOKS` | disabled | Set to `1` to log received webhook event ids. |
+| Variable                       | Default                                                    | Description                                                                                 |
+| ------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `PORT`                         | `3000`                                                     | Port the example server listens on. Must be a positive number.                              |
+| `DATABASE_URL`                 | `file:/tmp/anchor-kit-example-<uuid>.sqlite`               | Database location. `file:...` selects SQLite; otherwise PostgreSQL.                         |
+| `INTERACTIVE_DOMAIN`           | `http://localhost:3000`                                    | Interactive flow domain used by SEP-24.                                                     |
+| `SEP10_SIGNING_KEY`            | fresh random keypair                                       | SEP-10 challenge signing secret. Regenerated on every start unset.                          |
+| `INTERACTIVE_JWT_SECRET`       | `example-jwt-secret`                                       | Secret for SEP-24 interactive JWT tokens.                                                   |
+| `DISTRIBUTION_ACCOUNT_SECRET`  | `example-distribution-secret`                              | Distribution account secret key.                                                            |
+| `WEBHOOK_SECRET`               | unset                                                      | Webhook signing secret. When set, webhook signature verification is enabled.                |
+| `CHALLENGE_EXPIRATION_SECONDS` | `300`                                                      | SEP-10 challenge lifetime in seconds. Falls back to default on invalid/non-positive values. |
+| `ASSET_CODE`                   | `USDC`                                                     | Code for the example supported asset.                                                       |
+| `ASSET_ISSUER`                 | `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` | Issuer for the example supported asset.                                                     |
+| `WATCHERS_ENABLED`             | enabled                                                    | Set to `false` to disable background watchers.                                              |
+| `DEBUG_WEBHOOKS`               | disabled                                                   | Set to `1` to log received webhook event ids.                                               |
 
 ## Quick check
 

--- a/example/README.md
+++ b/example/README.md
@@ -18,11 +18,24 @@ bun run example/express-app.ts
 
 Server starts on `http://localhost:3000` by default.
 
-## Optional environment variables
+## Environment variables
 
-- `DATABASE_URL`: overrides the example database location
-- `CHALLENGE_EXPIRATION_SECONDS`: overrides the SEP-10 challenge lifetime in seconds. Defaults to `300`.
-- `WATCHERS_ENABLED`: set to `false` to disable background watchers. Defaults to enabled.
+All variables are optional. When unset the listed default applies.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `3000` | Port the example server listens on. Must be a positive number. |
+| `DATABASE_URL` | `file:/tmp/anchor-kit-example-<uuid>.sqlite` | Database location. `file:...` selects SQLite; otherwise PostgreSQL. |
+| `INTERACTIVE_DOMAIN` | `http://localhost:3000` | Interactive flow domain used by SEP-24. |
+| `SEP10_SIGNING_KEY` | fresh random keypair | SEP-10 challenge signing secret. Regenerated on every start unset. |
+| `INTERACTIVE_JWT_SECRET` | `example-jwt-secret` | Secret for SEP-24 interactive JWT tokens. |
+| `DISTRIBUTION_ACCOUNT_SECRET` | `example-distribution-secret` | Distribution account secret key. |
+| `WEBHOOK_SECRET` | unset | Webhook signing secret. When set, webhook signature verification is enabled. |
+| `CHALLENGE_EXPIRATION_SECONDS` | `300` | SEP-10 challenge lifetime in seconds. Falls back to default on invalid/non-positive values. |
+| `ASSET_CODE` | `USDC` | Code for the example supported asset. |
+| `ASSET_ISSUER` | `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` | Issuer for the example supported asset. |
+| `WATCHERS_ENABLED` | enabled | Set to `false` to disable background watchers. |
+| `DEBUG_WEBHOOKS` | disabled | Set to `1` to log received webhook event ids. |
 
 ## Quick check
 

--- a/tests/example-readme-env-vars.test.ts
+++ b/tests/example-readme-env-vars.test.ts
@@ -26,8 +26,9 @@ describe('example README documents all env vars', () => {
     }
 
     // Table documents the default behavior for each variable.
-    expect(readme).toContain('| `PORT` | `3000` |');
-    expect(readme).toContain('| `CHALLENGE_EXPIRATION_SECONDS` | `300` |');
-    expect(readme).toContain('| `WATCHERS_ENABLED` | enabled |');
+    // Use regex so assertions survive Prettier's table-column padding.
+    expect(readme).toMatch(/\| `PORT`\s+\| `3000`/);
+    expect(readme).toMatch(/\| `CHALLENGE_EXPIRATION_SECONDS`\s+\| `300`/);
+    expect(readme).toMatch(/\| `WATCHERS_ENABLED`\s+\| enabled/);
   });
 });

--- a/tests/example-readme-env-vars.test.ts
+++ b/tests/example-readme-env-vars.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('example README documents all env vars', () => {
+  it('lists every environment variable read by the example app', () => {
+    const readmePath = new URL('../example/README.md', import.meta.url);
+    const readme = readFileSync(readmePath, 'utf8');
+
+    const envVarsReadByExampleApp = [
+      'PORT',
+      'DATABASE_URL',
+      'INTERACTIVE_DOMAIN',
+      'SEP10_SIGNING_KEY',
+      'INTERACTIVE_JWT_SECRET',
+      'DISTRIBUTION_ACCOUNT_SECRET',
+      'WEBHOOK_SECRET',
+      'CHALLENGE_EXPIRATION_SECONDS',
+      'ASSET_CODE',
+      'ASSET_ISSUER',
+      'WATCHERS_ENABLED',
+      'DEBUG_WEBHOOKS',
+    ];
+
+    for (const envVar of envVarsReadByExampleApp) {
+      expect(readme).toContain(`\`${envVar}\``);
+    }
+
+    // Table documents the default behavior for each variable.
+    expect(readme).toContain('| `PORT` | `3000` |');
+    expect(readme).toContain('| `CHALLENGE_EXPIRATION_SECONDS` | `300` |');
+    expect(readme).toContain('| `WATCHERS_ENABLED` | enabled |');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Updates the example app README to document every environment variable read by `example/express-app.ts`, as a table with the current default for each. Defaults match the example app code.

## How to test?

`bun run test` — new `example README documents all env vars` suite asserts each env var read by the example app is listed.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #273
