### PR TITLE
Add integration test for transaction lookup without bearer token

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -1759,6 +1759,19 @@ describe('MVP Express-mounted integration', () => {
     }
   });
 
+  // ── Unauthenticated transaction lookup ───────────────────────────────────
+
+  it('17) GET /transactions/:id without bearer token returns 401', async () => {
+    const response = await invoke({
+      method: 'GET',
+      path: `/transactions/${transactionId}`,
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('unauthorized');
+    expect(response.body.message).toBe('Missing or invalid bearer token');
+  });
+
   // ── Non-positive deposit amounts ─────────────────────────────────────────
 
   it('16) deposit with amount of zero is rejected with 400', async () => {


### PR DESCRIPTION
## What does this PR do?

Adds integration coverage for unauthenticated transaction lookup: `GET /transactions/:id` without an `Authorization` header returns the current 401 unauthorized response.

## How to test?

`bun run test` — new `17) GET /transactions/:id without bearer token returns 401` case in `tests/mvp-express.integration.test.ts`.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #227
