### PR TITLE
Validate watchers.enabled as a boolean

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -67,6 +67,11 @@ function validateFrameworkNumbers(framework: AnchorKitConfig['framework']): bool
     throw new Error('framework.queue.concurrency must be >= 1');
   }
 
+  const watchersEnabled = framework.watchers?.enabled;
+  if (watchersEnabled !== undefined && typeof watchersEnabled !== 'boolean') {
+    throw new Error('framework.watchers.enabled must be a boolean');
+  }
+
   if (framework.watchers?.pollIntervalMs !== undefined && framework.watchers.pollIntervalMs < 10) {
     throw new Error('framework.watchers.pollIntervalMs must be >= 10');
   }

--- a/tests/core/config-validation-improvements.test.ts
+++ b/tests/core/config-validation-improvements.test.ts
@@ -155,6 +155,30 @@ describe('Config Validation Improvements (#124, #125)', () => {
     });
   });
 
+  it('should validate watchers.enabled as an optional boolean', () => {
+    for (const value of ['true', 1]) {
+      const config = new AnchorConfig({
+        ...validBaseConfig,
+        framework: {
+          ...validBaseConfig.framework,
+          watchers: { enabled: value as unknown as boolean },
+        },
+      });
+      expect(() => config.validate()).toThrow(/watchers.enabled must be a boolean/);
+    }
+
+    for (const value of [true, false, undefined]) {
+      const config = new AnchorConfig({
+        ...validBaseConfig,
+        framework: {
+          ...validBaseConfig.framework,
+          watchers: { enabled: value },
+        },
+      });
+      expect(() => config.validate()).not.toThrow();
+    }
+  });
+
   describe('Runtime Config Validation (#207)', () => {
     it('should reject redis queue backend during initialization', async () => {
       const redisConfig = {


### PR DESCRIPTION
## What does this PR do?
Rejects non-boolean `watchers.enabled` values while preserving valid booleans and defaults.

## How to test?
`bun test tests/core/config-validation-improvements.test.ts`

## Checklist
- [x] Added tests for the change.
- [x] Ran the focused test.

## Issue Reference
Closes #380