### PR TITLE
Cover stop-before-start background lifecycle

### DIFF
--- a/tests/runtime/background-lifecycle.test.ts
+++ b/tests/runtime/background-lifecycle.test.ts
@@ -1,0 +1,50 @@
+import { createAnchor, makeSqliteDbUrlForTests } from '@/core/factory.ts';
+import { Keypair } from '@stellar/stellar-sdk';
+import { unlinkSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const databaseUrls: string[] = [];
+
+afterEach(() => {
+  for (const databaseUrl of databaseUrls.splice(0)) {
+    try {
+      unlinkSync(databaseUrl.slice('file:'.length));
+    } catch {
+      // The adapter may already have removed the temporary database.
+    }
+  }
+});
+
+describe('AnchorInstance background lifecycle', () => {
+  it('allows stop-before-start and can still start and stop later', async () => {
+    const databaseUrl = makeSqliteDbUrlForTests();
+    databaseUrls.push(databaseUrl);
+
+    const anchor = createAnchor({
+      network: { network: 'testnet' },
+      server: { interactiveDomain: 'https://anchor.example.com' },
+      security: {
+        sep10SigningKey: Keypair.random().secret(),
+        interactiveJwtSecret: 'jwt-test-secret',
+        distributionAccountSecret: 'distribution-test-secret',
+      },
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+      framework: {
+        database: { provider: 'sqlite', url: databaseUrl },
+      },
+    });
+
+    await anchor.init();
+    await expect(anchor.stopBackgroundJobs()).resolves.toBeUndefined();
+    await anchor.startBackgroundJobs();
+    await anchor.stopBackgroundJobs();
+    await anchor.shutdown();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds lifecycle coverage for stopping background jobs before starting them, then starting and stopping successfully.

## How to test?

- bun test tests/runtime/background-lifecycle.test.ts

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #367