### PR TITLE
Cover auth token array-body rejection

### DIFF
--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -18,7 +18,7 @@ interface TestRequestOptions {
   method?: string;
   path: string;
   headers?: Record<string, string>;
-  body?: Record<string, unknown>;
+  body?: unknown;
   rawBody?: string;
 }
 
@@ -1825,6 +1825,19 @@ describe('MVP Express-mounted integration', () => {
     expect(response.status).toBe(400);
     expect(response.body.error).toBe('invalid_request');
     expect(response.body.message).toBe('Request body must be valid JSON');
+  });
+
+  it('15e) JSON array on POST /auth/token returns 400', async () => {
+    const response = await invoke({
+      method: 'POST',
+      path: '/auth/token',
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '10.0.0.9' },
+      body: ['account', 'challenge'],
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('invalid_request');
+    expect(response.body.message).toBe('Request JSON body must be an object');
   });
 
   it('15e) malformed JSON on POST /transactions/deposit/interactive returns 400', async () => {


### PR DESCRIPTION
## What does this PR do?

Adds integration coverage that keeps JSON arrays rejected by the `/auth/token` endpoint with the documented invalid-request response.

## How to test?

- bun test tests/mvp-express.integration.test.ts

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #346