### PR TITLE
Support sqlite database URLs in the SQLite adapter

### DIFF
--- a/src/runtime/database/sql-database-adapter.ts
+++ b/src/runtime/database/sql-database-adapter.ts
@@ -22,6 +22,7 @@ interface PostgresClient {
 }
 
 const SQLITE_FILE_PREFIX = 'file:';
+const SQLITE_URL_PREFIX = 'sqlite:';
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -30,6 +31,9 @@ function nowIso(): string {
 function toSqlitePath(url: string): string {
   if (url.startsWith(SQLITE_FILE_PREFIX)) {
     return url.slice(SQLITE_FILE_PREFIX.length);
+  }
+  if (url.startsWith(SQLITE_URL_PREFIX)) {
+    return url.slice(SQLITE_URL_PREFIX.length);
   }
   return url;
 }

--- a/tests/runtime/database/sql-database-adapter.test.ts
+++ b/tests/runtime/database/sql-database-adapter.test.ts
@@ -85,4 +85,35 @@ describe('SqlDatabaseAdapter (sqlite)', () => {
     expect(pending).toHaveLength(1);
     expect(pending[0]?.id).toBe('tx-old');
   });
+
+  it('connects and migrates a sqlite URL', async () => {
+    const sqlitePath = makeSqliteDbUrlForTests().slice('file:'.length);
+    const sqliteAdapter = new SqlDatabaseAdapter({
+      provider: 'sqlite',
+      url: `sqlite:${sqlitePath}`,
+    });
+
+    try {
+      await sqliteAdapter.connect();
+      await sqliteAdapter.migrate();
+      await sqliteAdapter.insertAuthChallenge({
+        id: 'sqlite-url-challenge',
+        account: 'GB7W6F6S6LFQXCNHZVKI53ZJHULPF4E66YW2LJ3F4PAEPGZF5FY2B7ZB',
+        challenge: 'sqlite-url-test',
+        expiresAt: '2099-12-31T23:59:59.000Z',
+      });
+
+      await expect(sqliteAdapter.getAuthChallengeByChallenge('sqlite-url-test')).resolves.toEqual(
+        expect.objectContaining({ challenge: 'sqlite-url-test' }),
+      );
+    } finally {
+      await sqliteAdapter.disconnect();
+      const { unlinkSync } = await import('node:fs');
+      try {
+        unlinkSync(sqlitePath);
+      } catch {
+        // The temporary database may not exist for in-memory adapters.
+      }
+    }
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Adds support for converting `sqlite:` URLs to the Bun SQLite path while preserving `file:` URL behavior.

## How to test?

- `bun test tests/runtime/database/sql-database-adapter.test.ts`
- `bun test tests/runtime/background-shutdown.test.ts`

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run bun run test and bun run lint locally.

## Issue Reference

Closes #369