### PR TITLE
Webhook signature verification

### DIFF
--- a/docs/mvp-express.md
+++ b/docs/mvp-express.md
@@ -51,7 +51,13 @@ import express from 'express';
 import { createAnchor } from 'anchor-kit';
 
 const app = express();
-app.use(express.json());
+app.use(
+  express.json({
+    verify: (req, _res, buf) => {
+      (req as { rawBody?: string }).rawBody = buf.toString('utf8');
+    },
+  }),
+);
 
 const anchor = createAnchor({
   network: { network: 'testnet' },
@@ -108,6 +114,8 @@ process.on('SIGTERM', async () => {
   server.close();
 });
 ```
+
+Webhook signature verification depends on the exact raw request body bytes. Configure the JSON parser `verify` hook before mounting `anchor.getExpressRouter()` so Anchor-Kit can compare the incoming `x-anchor-signature` against the unmodified payload.
 
 ## 5) Webhook callback behavior
 

--- a/tests/readme-webhook-raw-body.test.ts
+++ b/tests/readme-webhook-raw-body.test.ts
@@ -13,4 +13,15 @@ describe('README webhook raw body guidance', () => {
     expect(readme).toContain('exact request body bytes');
     expect(readme).toContain('anchor.getExpressRouter()');
   });
+
+  it('documents raw body capture in the MVP Express guide', () => {
+    const guidePath = new URL('../docs/mvp-express.md', import.meta.url);
+    const guide = readFileSync(guidePath, 'utf8');
+
+    expect(guide).toContain('express.json');
+    expect(guide).toContain('verify');
+    expect(guide).toContain('rawBody');
+    expect(guide).toContain('exact raw request body bytes');
+    expect(guide).toContain('anchor.getExpressRouter()');
+  });
 });


### PR DESCRIPTION
Webhook signature verification requires the exact raw request bytes. Update the MVP Express example to use the JSON parser verify hook to store req.rawBody before mounting the Anchor router.

Closes #394

