### PR TITLE
feat(config): validate KYC age bounds

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -308,10 +308,44 @@ export const AnchorKitConfigSchema = {
   },
 };
 
+function validateKycConfig(kyc: AnchorKitConfig['kyc']): boolean {
+  if (!kyc) return true;
+
+  const { minAge, maxAge } = kyc;
+
+  if (minAge !== undefined) {
+    if (
+      typeof minAge !== 'number' ||
+      !Number.isFinite(minAge) ||
+      minAge < 0 ||
+      !Number.isInteger(minAge)
+    ) {
+      throw new Error('kyc.minAge must be a finite non-negative integer');
+    }
+  }
+
+  if (maxAge !== undefined) {
+    if (
+      typeof maxAge !== 'number' ||
+      !Number.isFinite(maxAge) ||
+      maxAge < 0 ||
+      !Number.isInteger(maxAge)
+    ) {
+      throw new Error('kyc.maxAge must be a finite non-negative integer');
+    }
+  }
+
+  if (minAge !== undefined && maxAge !== undefined && minAge > maxAge) {
+    throw new Error('kyc.minAge must be less than or equal to kyc.maxAge');
+  }
+
+  return true;
+}
+
 function validateAnchorKitConfig(config: AnchorKitConfig): boolean {
   if (!config) throw new Error('Configuration object is missing');
 
-  const { network, server, security, assets, framework, metadata } = config;
+  const { network, server, security, assets, framework, metadata, kyc } = config;
 
   if (!network) throw new Error('Missing required top-level field: network');
   if (!server) throw new Error('Missing required top-level field: server');
@@ -338,6 +372,7 @@ function validateAnchorKitConfig(config: AnchorKitConfig): boolean {
   }
 
   validateFrameworkConfig(framework, server, metadata);
+  validateKycConfig(kyc);
 
   return true;
 }

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -286,5 +286,47 @@ describe('AnchorConfig', () => {
       expect(() => config.validate()).toThrow(ConfigError);
       expect(() => config.validate()).toThrow(/authTokenLifetimeSeconds must be > 0/);
     });
+
+    describe('KYC age bounds validation', () => {
+      it.each([
+        { kyc: { minAge: 18 }, name: 'minimum age only' },
+        { kyc: { maxAge: 120 }, name: 'maximum age only' },
+        { kyc: { minAge: 18, maxAge: 120 }, name: 'ordered age range' },
+        { kyc: { minAge: 0, maxAge: 0 }, name: 'zero age bounds' },
+      ])('should accept valid KYC $name', ({ kyc }) => {
+        const config = new AnchorConfig({
+          ...validBaseConfig,
+          kyc,
+        });
+
+        expect(() => config.validate()).not.toThrow();
+      });
+
+      it.each([
+        { kyc: { minAge: -1 }, message: /kyc\.minAge must be a finite non-negative integer/ },
+        { kyc: { maxAge: -1 }, message: /kyc\.maxAge must be a finite non-negative integer/ },
+        { kyc: { minAge: 18.5 }, message: /kyc\.minAge must be a finite non-negative integer/ },
+        {
+          kyc: { maxAge: Number.NaN },
+          message: /kyc\.maxAge must be a finite non-negative integer/,
+        },
+        {
+          kyc: { minAge: Number.POSITIVE_INFINITY },
+          message: /kyc\.minAge must be a finite non-negative integer/,
+        },
+        {
+          kyc: { minAge: 65, maxAge: 18 },
+          message: /kyc\.minAge must be less than or equal to kyc\.maxAge/,
+        },
+      ])('should reject invalid KYC age bounds %#', ({ kyc, message }) => {
+        const config = new AnchorConfig({
+          ...validBaseConfig,
+          kyc,
+        });
+
+        expect(() => config.validate()).toThrow(ConfigError);
+        expect(() => config.validate()).toThrow(message);
+      });
+    });
   });
 });


### PR DESCRIPTION
Validate defined age bounds as non-negative finite integers. Reject configs where minAge is greater than maxAge. Add table-driven tests for KYC age validation.

Closes #389


