### PR TITLE
Validate operational.website as HTTP/HTTPS URL

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -139,6 +139,7 @@ function validateFrameworkRateLimit(framework: AnchorKitConfig['framework']): bo
 function validateFrameworkUrls(
   metadata: AnchorKitConfig['metadata'],
   server: AnchorKitConfig['server'],
+  operational: AnchorKitConfig['operational'],
 ): boolean {
   if (server.interactiveDomain && !isValidUrlString(server.interactiveDomain)) {
     throw new Error('Invalid URL format for server.interactiveDomain');
@@ -148,6 +149,10 @@ function validateFrameworkUrls(
     throw new Error('Invalid URL format for metadata.tomlUrl');
   }
 
+  if (operational?.website && !isValidUrlString(operational.website)) {
+    throw new Error('Invalid URL format for operational.website');
+  }
+
   return true;
 }
 
@@ -155,11 +160,12 @@ function validateFrameworkConfig(
   framework: AnchorKitConfig['framework'],
   server: AnchorKitConfig['server'],
   metadata: AnchorKitConfig['metadata'],
+  operational: AnchorKitConfig['operational'],
 ): boolean {
   validateFrameworkDatabase(framework);
   validateFrameworkNumbers(framework);
   validateFrameworkRateLimit(framework);
-  validateFrameworkUrls(metadata, server);
+  validateFrameworkUrls(metadata, server, operational);
   return true;
 }
 
@@ -311,7 +317,7 @@ export const AnchorKitConfigSchema = {
 function validateAnchorKitConfig(config: AnchorKitConfig): boolean {
   if (!config) throw new Error('Configuration object is missing');
 
-  const { network, server, security, assets, framework, metadata } = config;
+  const { network, server, security, assets, framework, metadata, operational } = config;
 
   if (!network) throw new Error('Missing required top-level field: network');
   if (!server) throw new Error('Missing required top-level field: server');
@@ -337,7 +343,7 @@ function validateAnchorKitConfig(config: AnchorKitConfig): boolean {
     }
   }
 
-  validateFrameworkConfig(framework, server, metadata);
+  validateFrameworkConfig(framework, server, metadata, operational);
 
   return true;
 }

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -195,3 +195,139 @@ describe('Asset Validation (#254)', () => {
     expect(() => anchor.validate()).toThrow(/Invalid asset at index 0/);
   });
 });
+
+describe('Operational Website Validation (#388)', () => {
+  const baseConfig: AnchorKitConfig = {
+    network: { network: 'testnet' },
+    server: { port: 3000 },
+    security: {
+      sep10SigningKey: 'secret-key-10',
+      interactiveJwtSecret: 'jwt-secret',
+      distributionAccountSecret: 'dist-secret',
+    },
+    assets: {
+      assets: [
+        {
+          code: 'USDC',
+          issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+        },
+      ],
+    },
+    framework: {
+      database: {
+        provider: 'postgres',
+        url: 'postgresql://localhost:5432/anchor',
+      },
+    },
+  };
+
+  it('should accept valid HTTP website URL', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'http://example.com',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).not.toThrow();
+  });
+
+  it('should accept valid HTTPS website URL', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'https://example.com',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).not.toThrow();
+  });
+
+  it('should accept config without operational.website (optional field)', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        name: 'Test Anchor',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).not.toThrow();
+  });
+
+  it('should accept config without operational section', () => {
+    const anchor = new AnchorConfig(baseConfig);
+    expect(() => anchor.validate()).not.toThrow();
+  });
+
+  it('should reject malformed URL', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'not-a-valid-url',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
+  });
+
+  it('should reject FTP scheme', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'ftp://example.com',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
+  });
+
+  it('should reject javascript: scheme', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'javascript:alert(1)',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
+  });
+
+  it('should reject data: scheme', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'data:text/html,<script>alert(1)</script>',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
+  });
+
+  it('should reject file: scheme', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'file:///etc/passwd',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
+  });
+
+  it('should reject mailto: scheme', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        website: 'mailto:test@example.com',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
+  });
+});


### PR DESCRIPTION
- Add validation for operational.website to ensure it's a valid HTTP or HTTPS URL
- Keep the field optional (can be omitted)
- Reject malformed URLs and non-HTTP schemes (ftp, javascript:, data:, file:, mailto:)
- Add comprehensive test coverage for accepted and rejected schemes
- Update validateFrameworkUrls to accept operational parameter
- Update validateFrameworkConfig to pass operational to validateFrameworkUrls
- Update validateAnchorKitConfig to extract operational from config

Closes #388

