### PR TITLE
test(webhook): assert processedAt and errorMessage after marking proc…

### DIFF
--- a/tests/runtime/sql-adapter-webhook-dedupe.test.ts
+++ b/tests/runtime/sql-adapter-webhook-dedupe.test.ts
@@ -94,4 +94,42 @@ describe('SqlDatabaseAdapter – webhook event deduplication (sqlite)', () => {
     expect(resultA.record.eventId).toBe(eventIdA);
     expect(resultB.record.eventId).toBe(eventIdB);
   });
+
+  it('after marking processed, fetching the same event_id returns status=processed, non-null processedAt, and null errorMessage', async () => {
+    const eventId = `evt-${randomUUID()}`;
+    const payload = { type: 'deposit.completed', amount: '50' };
+
+    // Insert the event
+    const { record: inserted } = await db.insertOrGetWebhookEvent({
+      id: randomUUID(),
+      eventId,
+      provider: 'test-provider',
+      payload,
+    });
+    expect(inserted.status).toBe('pending');
+    expect(inserted.processedAt).toBeNull();
+
+    // Mark it as processed (no errorMessage)
+    await db.updateWebhookEventStatus({
+      id: inserted.id,
+      status: 'processed',
+    });
+
+    // Re-fetch via the canonical insert-or-get path using the same eventId
+    const { record: fetched, inserted: wasInserted } = await db.insertOrGetWebhookEvent({
+      id: randomUUID(),
+      eventId,
+      provider: 'test-provider',
+      payload,
+    });
+
+    // Should return the existing record, not insert a new one
+    expect(wasInserted).toBe(false);
+    expect(fetched.id).toBe(inserted.id);
+
+    // Status fields must reflect the processed update
+    expect(fetched.status).toBe('processed');
+    expect(fetched.processedAt).not.toBeNull();
+    expect(fetched.errorMessage).toBeNull();
+  });
 });


### PR DESCRIPTION
…essed

Insert a webhook event, call updateWebhookEventStatus with status='processed', re-fetch via insertOrGetWebhookEvent and assert:
- status === 'processed'
- processedAt is non-null
- errorMessage is null
- wasInserted is false (dedup path)

Closes #374

## What does this PR do?

Please provide a brief description of the changes in this PR.

## How to test?

Please describe how to verify the changes.

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #374 
