### PR TITLE
test(sqlite): cover pending watcher task limit and oldest-first ordering (#376)

### DIFF
--- a/tests/runtime/sql-adapter-watcher-tasks.test.ts
+++ b/tests/runtime/sql-adapter-watcher-tasks.test.ts
@@ -5,6 +5,42 @@ import { unlinkSync } from 'node:fs';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { DatabaseAdapter } from '@/runtime/interfaces.ts';
 
+interface SqliteHandle {
+  exec(sql: string): void;
+  prepare(sql: string): { run(...params: unknown[]): unknown };
+}
+
+function getSqlite(db: DatabaseAdapter): SqliteHandle {
+  const sqlite = (db as unknown as { sqlite?: SqliteHandle }).sqlite;
+  if (!sqlite) {
+    throw new Error('SQLite handle unavailable for test');
+  }
+  return sqlite;
+}
+
+function insertWatcherRow(
+  db: DatabaseAdapter,
+  fields: {
+    id: string;
+    watcherName: string;
+    payload: Record<string, unknown>;
+    status: 'pending' | 'processed';
+    createdAt: string;
+  },
+): void {
+  getSqlite(db)
+    .prepare(
+      'INSERT INTO watcher_tasks (id, watcher_name, payload, status, error_message, processed_at, created_at) VALUES (?, ?, ?, ?, NULL, NULL, ?)',
+    )
+    .run(
+      fields.id,
+      fields.watcherName,
+      JSON.stringify(fields.payload),
+      fields.status,
+      fields.createdAt,
+    );
+}
+
 describe('SqlDatabaseAdapter – watcher task persistence and processed counts', () => {
   const dbUrl = makeSqliteDbUrlForTests();
   const dbPath = dbUrl.startsWith('file:') ? dbUrl.slice('file:'.length) : dbUrl;
@@ -27,18 +63,12 @@ describe('SqlDatabaseAdapter – watcher task persistence and processed counts',
 
   beforeEach(async () => {
     // Clean up watcher tasks between tests
-    const sqlite = (db as unknown as { sqlite?: { exec: (sql: string) => void } }).sqlite;
-    if (sqlite) {
-      sqlite.exec('DELETE FROM watcher_tasks');
-    }
+    getSqlite(db).exec('DELETE FROM watcher_tasks');
   });
 
   afterEach(async () => {
     // Ensure cleanup after each test
-    const sqlite = (db as unknown as { sqlite?: { exec: (sql: string) => void } }).sqlite;
-    if (sqlite) {
-      sqlite.exec('DELETE FROM watcher_tasks');
-    }
+    getSqlite(db).exec('DELETE FROM watcher_tasks');
   });
 
   it('inserts a watcher task, updates status to processed, and counts it correctly', async () => {
@@ -130,5 +160,83 @@ describe('SqlDatabaseAdapter – watcher task persistence and processed counts',
 
     // No pending tasks left
     expect(await db.listPendingWatcherTasks(10)).toHaveLength(0);
+  });
+
+  it('caps the returned pending watcher tasks at the requested limit', async () => {
+    const watcherName = 'limit-watcher';
+    const total = 5;
+    const baseTimestamp = Date.parse('2024-01-01T00:00:00.000Z');
+
+    for (let i = 0; i < total; i++) {
+      insertWatcherRow(db, {
+        id: randomUUID(),
+        watcherName,
+        payload: { order: i + 1 },
+        status: 'pending',
+        // Spread timestamps by an hour so total ordering is deterministic.
+        createdAt: new Date(baseTimestamp + i * 60 * 60 * 1000).toISOString(),
+      });
+    }
+
+    // Insert an additional non-pending row to confirm pending-only filtering while
+    // asserting the limit applies to pending rows alone.
+    insertWatcherRow(db, {
+      id: randomUUID(),
+      watcherName,
+      payload: { order: 99 },
+      status: 'processed',
+      createdAt: new Date(baseTimestamp - 60 * 60 * 1000).toISOString(),
+    });
+
+    // Sanity check: every pending row is persisted before we exercise the limit.
+    expect((await db.listPendingWatcherTasks(total + 1)).length).toBe(total);
+
+    const limited = await db.listPendingWatcherTasks(2);
+
+    // Result count must not exceed the requested limit.
+    expect(limited).toHaveLength(2);
+
+    // The two oldest pending IDs should be the ones with orders 1 and 2.
+    expect(limited.map((task) => task.payload.order)).toEqual([1, 2]);
+  });
+
+  it('returns pending watcher tasks in oldest-first order regardless of insertion order', async () => {
+    const watcherName = 'order-watcher';
+    const baseTimestamp = Date.parse('2024-02-01T00:00:00.000Z');
+
+    // Insert five pending tasks with deterministic timestamps but in REVERSE
+    // chronological order. This proves the ordering is driven by created_at,
+    // not by primary-key insertion order.
+    const insertionOrder = [5, 4, 3, 2, 1];
+    for (const order of insertionOrder) {
+      insertWatcherRow(db, {
+        id: randomUUID(),
+        watcherName,
+        payload: { order },
+        status: 'pending',
+        createdAt: new Date(baseTimestamp + (order - 1) * 60 * 60 * 1000).toISOString(),
+      });
+    }
+
+    // Mix in a processed task whose created_at falls between the earliest two
+    // pending tasks; it must not appear in oldest-first pending results.
+    insertWatcherRow(db, {
+      id: randomUUID(),
+      watcherName,
+      payload: { order: 0 },
+      status: 'processed',
+      createdAt: new Date(baseTimestamp + 30 * 60 * 1000).toISOString(),
+    });
+
+    const pending = await db.listPendingWatcherTasks(10);
+
+    // Only the five pending tasks are returned and they are oldest-first.
+    expect(pending).toHaveLength(insertionOrder.length);
+    expect(pending.map((task) => task.payload.order)).toEqual([1, 2, 3, 4, 5]);
+
+    // A smaller limit still preserves the oldest-first ordering.
+    const limited = await db.listPendingWatcherTasks(3);
+    expect(limited).toHaveLength(3);
+    expect(limited.map((task) => task.payload.order)).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
## Summary

Closes #376

Pending watcher task coverage previously fetched all rows but did not verify the requested `limit` argument or oldest-first ordering of `listPendingWatcherTasks`. This PR adds two focused tests that pin down both behaviours so workers can resume a backlog with predictable bounded reads.

## Changes

One file changed: `tests/runtime/sql-adapter-watcher-tasks.test.ts` (+116 / -8)

1. New test `caps the returned pending watcher tasks at the requested limit`
   - Inserts 5 pending rows with deterministic ISO `created_at` values (one hour apart) plus one extra `processed` row outside the pending window.
   - Calls `listPendingWatcherTasks(2)` and asserts the result count is exactly 2 (`toHaveLength(2)`) - the acceptance criterion `result count does not exceed the requested limit`.
   - Asserts the two returned tasks are the oldest pending ones (payloads `{order: 1, 2}`).

2. New test `returns pending watcher tasks in oldest-first order regardless of insertion order`
   - Inserts 5 pending rows with deterministic timestamps but in **reverse** chronological order (5,4,3,2,1) to prove ordering is driven by `created_at`, not primary-key insertion order.
   - Mixes in a `processed` row whose timestamp lies between the two oldest pendings; it must never appear.
   - Calls `listPendingWatcherTasks(10)` and asserts payloads return as `[1,2,3,4,5]`.
   - Re-calls with `limit=3` and asserts `[1,2,3]` - the limit and ordering interact correctly.

A small `getSqlite(db)` helper and an `insertWatcherRow` helper were added; the existing inline cast in `beforeEach`/`afterEach` now also uses `getSqlite(db)` for consistency. The helper relies on the migration applied in `beforeAll`, so no schema or runtime dependency changes are needed.

## Acceptance criteria

- Result count does not exceed the requested limit - covered by test 1 (`expect(...).toHaveLength(2)`).
- Returned tasks are the oldest pending tasks in order - covered by tests 1 and 2 (payload order assertions).

## Testing notes

- `bun test` (or `npx vitest run`) on the new branch passes the focused file (`tests/runtime/sql-adapter-watcher-tasks.test.ts`, 4 tests green in ~40 ms) and the full suite reports no new failures introduced by this change.
- Timestamps are computed from `Date.parse(\"2024-01-01T00:00:00.000Z\")` plus integer hour arithmetic and `.toISOString()`, so ordering does not depend on test execution speed.
- Test isolation is preserved by the existing `beforeEach`/`afterEach` `DELETE FROM watcher_tasks` cleanup.
- The unrelated `tests/runtime/background-shutdown.test.ts` failure observed when running the full suite locally via `npx vitest run` exists on plain `upstream/main` as well (confirmed by stashing this change and rerunning) and stems from `tests/__mocks__/bun-sqlite.ts` passing a parameter array that does not match the prepared statement; it is out of scope for #376 and not caused by this PR.

## Out of scope / non-changes

- No source changes (`src/**` untouched).
- No new runtime dependencies.
- No changes to the existing tests.
- Husky hooks remain unchanged (`.husky/post-checkout`, `post-commit`, `post-merge`, `pre-push` were already untracked locally and are not included in this commit).

Closes #376