### PR TITLE
fix: reject duplicate configured asset codes (#384)

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -366,6 +366,7 @@ function validateAnchorKitConfig(config: AnchorKitConfig): boolean {
     throw new Error('At least one asset must be configured in assets.assets');
   }
 
+  const seenCodes = new Set<string>();
   for (let i = 0; i < assets.assets.length; i++) {
     const asset = assets.assets[i];
     if (!AssetSchema.isValid(asset)) {
@@ -375,6 +376,11 @@ function validateAnchorKitConfig(config: AnchorKitConfig): boolean {
         `Invalid asset at index ${i}${codeStr}: asset.code must be a non-empty string and asset.issuer must be a valid Stellar public key.`,
       );
     }
+    const code = asset.code;
+    if (seenCodes.has(code)) {
+      throw new Error(`Duplicate asset code detected: ${code}`);
+    }
+    seenCodes.add(code);
   }
 
   validateFrameworkConfig(framework, server, metadata, operational);

--- a/tests/core/asset-validation.test.ts
+++ b/tests/core/asset-validation.test.ts
@@ -194,4 +194,45 @@ describe('Asset Validation (#254)', () => {
     expect(() => anchor.validate()).toThrow();
     expect(() => anchor.validate()).toThrow(/Invalid asset at index 0/);
   });
+
+  it('should reject duplicate asset codes and report the duplicate code in the error message', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Duplicate asset code detected: USDC/);
+  });
+
+  it('should accept configuration with multiple distinct asset codes', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      assets: {
+        assets: [
+          {
+            code: 'USDC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+          {
+            code: 'EURC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).not.toThrow();
+  });
 });


### PR DESCRIPTION
Closes #384

---

### Summary
Detects duplicate asset codes during top-level configuration validation and reports the duplicated code in the error message.

### Why this matters
Duplicate asset codes make `getAsset()` and advertised asset settings depend on array order, causing potential inconsistencies in SDK lookup and advertisement behavior.

### Proposed Changes
- Added a duplicate check inside `validateAnchorKitConfig()` in `src/utils/validation-helpers.ts` using a `Set` to track processed asset codes.
- Added validation error reporting that raises an exception if a duplicate is found (e.g., `Duplicate asset code detected: <asset_code>`).
- Added unit tests to `tests/core/asset-validation.test.ts` verifying that duplicate asset configs are rejected with the correct error message, while multiple distinct assets continue to validate successfully.
