### PR TITLE
fix: validate configured operational support email address (#387)

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -153,6 +153,13 @@ function validateFrameworkUrls(
     throw new Error('Invalid URL format for operational.website');
   }
 
+  if (
+    operational?.supportEmail !== undefined &&
+    !ValidationUtils.isValidEmail(operational.supportEmail)
+  ) {
+    throw new Error('Invalid email format for operational.supportEmail');
+  }
+
   return true;
 }
 

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -287,6 +287,35 @@ describe('AnchorConfig', () => {
       expect(() => config.validate()).toThrow(/authTokenLifetimeSeconds must be > 0/);
     });
 
+    describe('operational supportEmail validation', () => {
+      it('should accept valid operational supportEmail', () => {
+        const config = new AnchorConfig({
+          ...validBaseConfig,
+          operational: { supportEmail: 'support@example.com' },
+        });
+        expect(() => config.validate()).not.toThrow();
+      });
+
+      it('should accept omitted operational supportEmail', () => {
+        const config = new AnchorConfig({
+          ...validBaseConfig,
+          operational: { name: 'Test Anchor' },
+        });
+        expect(() => config.validate()).not.toThrow();
+      });
+
+      it('should reject malformed operational supportEmail', () => {
+        const config = new AnchorConfig({
+          ...validBaseConfig,
+          operational: { supportEmail: 'invalid-email-address' },
+        });
+        expect(() => config.validate()).toThrow(ConfigError);
+        expect(() => config.validate()).toThrow(
+          /Invalid email format for operational.supportEmail/,
+        );
+      });
+    });
+
     describe('KYC age bounds validation', () => {
       it.each([
         { kyc: { minAge: 18 }, name: 'minimum age only' },

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -330,4 +330,29 @@ describe('Operational Website Validation (#388)', () => {
     expect(() => anchor.validate()).toThrow();
     expect(() => anchor.validate()).toThrow(/Invalid URL format for operational.website/);
   });
+
+  it('should accept valid support email', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        supportEmail: 'support@example.com',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).not.toThrow();
+  });
+
+  it('should reject malformed support email', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      operational: {
+        supportEmail: 'not-an-email',
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(
+      /Invalid email format for operational.supportEmail/,
+    );
+  });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -351,8 +351,6 @@ describe('Operational Website Validation (#388)', () => {
     };
     const anchor = new AnchorConfig(config);
     expect(() => anchor.validate()).toThrow();
-    expect(() => anchor.validate()).toThrow(
-      /Invalid email format for operational.supportEmail/,
-    );
+    expect(() => anchor.validate()).toThrow(/Invalid email format for operational.supportEmail/);
   });
 });


### PR DESCRIPTION
Validates operational.supportEmail using ValidationUtils.isValidEmail when provided during config validation. Leaves operational.supportEmail optional (omitted values and undefined pass). Adds unit test coverage for valid, omitted, and malformed support email values in top-level config and validation helper tests.

Closes #387

## What does this PR do?

Please provide a brief description of the changes in this PR.

## How to test?

Please describe how to verify the changes.

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have added tests for my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #397
