### PR TITLE
fix: validate Stellar asset code format

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -35,6 +35,10 @@ function isValidDatabaseUrlString(urlString: unknown): boolean {
   );
 }
 
+function isValidStellarAssetCode(code: string): boolean {
+  return /^[a-zA-Z0-9]{1,12}$/.test(code);
+}
+
 function isValidAssetAmount(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
@@ -173,7 +177,7 @@ function validateAsset(asset: unknown): asset is Asset {
   if (!asset || typeof asset !== 'object') return false;
   const a = asset as Record<string, unknown>;
 
-  if (!isNonEmptyString(a.code)) return false;
+  if (!isNonEmptyString(a.code) || !isValidStellarAssetCode(a.code)) return false;
   if (!isString(a.issuer) || !ValidationUtils.isValidStellarAddress(a.issuer)) return false;
 
   if (a.name !== undefined && !isString(a.name)) return false;

--- a/tests/core/asset-validation.test.ts
+++ b/tests/core/asset-validation.test.ts
@@ -103,6 +103,56 @@ describe('Asset Validation (#254)', () => {
     expect(() => anchor.validate()).toThrow(/Invalid asset at index 0/);
   });
 
+  it('should accept a 12-character alphanumeric asset code', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      assets: {
+        assets: [
+          {
+            code: 'ABCDEFGH1234',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).not.toThrow();
+  });
+
+  it('should reject an asset code longer than 12 characters', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      assets: {
+        assets: [
+          {
+            code: 'ABCDEFGH12345',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid asset at index 0/);
+  });
+
+  it('should reject an asset code containing non-alphanumeric characters', () => {
+    const config: AnchorKitConfig = {
+      ...baseConfig,
+      assets: {
+        assets: [
+          {
+            code: 'US-DC',
+            issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+          },
+        ],
+      },
+    };
+    const anchor = new AnchorConfig(config);
+    expect(() => anchor.validate()).toThrow();
+    expect(() => anchor.validate()).toThrow(/Invalid asset at index 0/);
+  });
+
   it('should reject asset with non-string code', () => {
     const config: AnchorKitConfig = {
       ...baseConfig,


### PR DESCRIPTION
## Summary
- `AssetSchema` previously accepted any non-empty `code` string, including values that can't represent a real Stellar asset code.
- Adds a format check requiring the code to be 1-12 alphanumeric characters (matching Stellar's `alphanum4`/`alphanum12` rules), rejecting empty, overlong, or invalid-character codes while still accepting existing valid codes like `USDC`.

## Changes
- `src/utils/validation-helpers.ts`: added `isValidStellarAssetCode` and wired it into `validateAsset` alongside the existing non-empty check.
- `tests/core/asset-validation.test.ts`: added boundary-case tests for a valid 12-character code, a rejected 13-character code, and a rejected code with a non-alphanumeric character.

## Testing
- `bun test` — 473 pass, 0 fail (full suite).
- `bun test tests/core/asset-validation.test.ts tests/verify-exports.test.ts` — 39 pass, 0 fail.

closes #385