### PR TITLE
test: add SQLite idempotency scope isolation coverage

### DIFF
--- a/tests/sqlite-idempotency.test.ts
+++ b/tests/sqlite-idempotency.test.ts
@@ -65,4 +65,60 @@ describe('sqlite idempotency persistence', () => {
     expect(fetched.status).toBe(status);
     expect(JSON.parse(fetched.response)).toEqual(response);
   });
+
+  it('isolates idempotency records by scope when the same key is used', () => {
+    const db = new Database(':memory:');
+
+    db.run(
+      `CREATE TABLE IF NOT EXISTS idempotency (
+        scope TEXT NOT NULL,
+        id_key TEXT NOT NULL,
+        hash TEXT NOT NULL,
+        status INTEGER NOT NULL,
+        response TEXT NOT NULL,
+        PRIMARY KEY(scope, id_key)
+      )`,
+    );
+
+    const key = 'shared-client-key';
+    const scopeA = 'sep24:deposit';
+    const scopeB = 'sep31:receive';
+
+    const responseA = { message: 'deposit success', id: 'resp-A' };
+    const responseB = { message: 'receive success', id: 'resp-B' };
+
+    // Insert Record A
+    db.run(
+      'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
+      [scopeA, key, 'hashA', 200, JSON.stringify(responseA)],
+    );
+
+    // Insert Record B
+    db.run(
+      'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
+      [scopeB, key, 'hashB', 201, JSON.stringify(responseB)],
+    );
+
+    // Assert both canonical records are inserted
+    const all = [...db.query('SELECT scope, id_key, hash, status, response FROM idempotency')];
+    expect(all.length).toBe(2);
+
+    // Lookup Scope A and assert correct record
+    const rowsA = [
+      ...db.query(
+        `SELECT response FROM idempotency WHERE scope = '${scopeA}' AND id_key = '${key}'`
+      ),
+    ];
+    expect(rowsA.length).toBe(1);
+    expect(JSON.parse((rowsA[0] as any).response)).toEqual(responseA);
+
+    // Lookup Scope B and assert correct record
+    const rowsB = [
+      ...db.query(
+        `SELECT response FROM idempotency WHERE scope = '${scopeB}' AND id_key = '${key}'`
+      ),
+    ];
+    expect(rowsB.length).toBe(1);
+    expect(JSON.parse((rowsB[0] as any).response)).toEqual(responseB);
+  });
 });

--- a/tests/sqlite-idempotency.test.ts
+++ b/tests/sqlite-idempotency.test.ts
@@ -1,124 +1,88 @@
-import Database from 'bun:sqlite';
+import {
+  createSqlDatabaseAdapter,
+  makeSqliteDbUrlForTests,
+} from '@/runtime/database/sql-database-adapter.ts';
+import type { DatabaseAdapter } from '@/runtime/interfaces.ts';
+import { unlinkSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 describe('sqlite idempotency persistence', () => {
-  it('stores and fetches an idempotency record by scope and key', () => {
-    const db = new Database(':memory:');
+  const dbUrl = makeSqliteDbUrlForTests();
+  const dbPath = dbUrl.slice('file:'.length);
+  let db: DatabaseAdapter;
 
-    db.run(
-      `CREATE TABLE IF NOT EXISTS idempotency (
-        scope TEXT NOT NULL,
-        id_key TEXT NOT NULL,
-        hash TEXT NOT NULL,
-        status INTEGER NOT NULL,
-        response TEXT NOT NULL,
-        PRIMARY KEY(scope, id_key)
-      )`,
-    );
-
-    const scope = 'sep24:deposit';
-    const key = 'client-123';
-    const hash = 'abcd1234';
-    const status = 200;
-    const response = { message: 'ok', id: 'resp-1' };
-
-    db.run(
-      'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
-      [scope, key, hash, status, JSON.stringify(response)],
-    );
-
-    const all = [...db.query('SELECT scope, id_key, hash, status, response FROM idempotency')];
-    expect(all.length).toBe(1);
-
-    const inserted = all[0] as {
-      scope: string;
-      id_key: string;
-      hash: string;
-      status: number;
-      response: string;
-    };
-
-    expect(inserted.scope).toBe(scope);
-    expect(inserted.id_key).toBe(key);
-    expect(inserted.hash).toBe(hash);
-    expect(inserted.status).toBe(status);
-    expect(JSON.parse(inserted.response)).toEqual(response);
-
-    const rows = [
-      ...db.query(
-        `SELECT scope, id_key, hash, status, response FROM idempotency WHERE scope = '${scope}' AND id_key = '${key}'`,
-      ),
-    ];
-
-    expect(rows.length).toBe(1);
-
-    const fetched = rows[0] as {
-      scope: string;
-      id_key: string;
-      hash: string;
-      status: number;
-      response: string;
-    };
-
-    expect(fetched.scope).toBe(scope);
-    expect(fetched.id_key).toBe(key);
-    expect(fetched.hash).toBe(hash);
-    expect(fetched.status).toBe(status);
-    expect(JSON.parse(fetched.response)).toEqual(response);
+  beforeAll(async () => {
+    db = createSqlDatabaseAdapter({ provider: 'sqlite', url: dbUrl });
+    await db.connect();
+    await db.migrate();
   });
 
-  it('isolates idempotency records by scope when the same key is used', () => {
-    const db = new Database(':memory:');
+  afterAll(async () => {
+    await db.disconnect();
+    try {
+      unlinkSync(dbPath);
+    } catch {
+      // Ignore cleanup errors when SQLite did not create a file.
+    }
+  });
 
-    db.run(
-      `CREATE TABLE IF NOT EXISTS idempotency (
-        scope TEXT NOT NULL,
-        id_key TEXT NOT NULL,
-        hash TEXT NOT NULL,
-        status INTEGER NOT NULL,
-        response TEXT NOT NULL,
-        PRIMARY KEY(scope, id_key)
-      )`,
+  it('stores and fetches an idempotency record by scope and key', async () => {
+    const scope = 'sep24:deposit';
+    const key = 'client-123';
+    const responseBody = JSON.stringify({ message: 'ok', id: 'resp-1' });
+
+    const inserted = await db.insertOrGetIdempotencyRecord({
+      id: 'idempotency-1',
+      scope,
+      idempotencyKey: key,
+      requestHash: 'abcd1234',
+      statusCode: 200,
+      responseBody,
+    });
+
+    expect(inserted).toEqual(
+      expect.objectContaining({
+        id: 'idempotency-1',
+        scope,
+        idempotencyKey: key,
+        requestHash: 'abcd1234',
+        statusCode: 200,
+        responseBody,
+      }),
     );
+    await expect(db.getIdempotencyRecord(scope, key)).resolves.toEqual(inserted);
+  });
 
+  it('isolates idempotency records by scope when the same key is used', async () => {
     const key = 'shared-client-key';
     const scopeA = 'sep24:deposit';
     const scopeB = 'sep31:receive';
+    const responseA = JSON.stringify({ message: 'deposit success', id: 'resp-A' });
+    const responseB = JSON.stringify({ message: 'receive success', id: 'resp-B' });
 
-    const responseA = { message: 'deposit success', id: 'resp-A' };
-    const responseB = { message: 'receive success', id: 'resp-B' };
+    const recordA = await db.insertOrGetIdempotencyRecord({
+      id: 'idempotency-scope-a',
+      scope: scopeA,
+      idempotencyKey: key,
+      requestHash: 'hashA',
+      statusCode: 200,
+      responseBody: responseA,
+    });
+    const recordB = await db.insertOrGetIdempotencyRecord({
+      id: 'idempotency-scope-b',
+      scope: scopeB,
+      idempotencyKey: key,
+      requestHash: 'hashB',
+      statusCode: 201,
+      responseBody: responseB,
+    });
 
-    // Insert Record A
-    db.run(
-      'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
-      [scopeA, key, 'hashA', 200, JSON.stringify(responseA)],
-    );
-
-    // Insert Record B
-    db.run(
-      'INSERT INTO idempotency (scope, id_key, hash, status, response) VALUES (?, ?, ?, ?, ?)',
-      [scopeB, key, 'hashB', 201, JSON.stringify(responseB)],
-    );
-
-    // Assert both canonical records are inserted
-    const all = [...db.query('SELECT scope, id_key, hash, status, response FROM idempotency')];
-    expect(all.length).toBe(2);
-
-    // Lookup Scope A and assert correct record
-    const rowsA = [
-      ...db.query(
-        `SELECT response FROM idempotency WHERE scope = '${scopeA}' AND id_key = '${key}'`
-      ),
-    ];
-    expect(rowsA.length).toBe(1);
-    expect(JSON.parse((rowsA[0] as any).response)).toEqual(responseA);
-
-    // Lookup Scope B and assert correct record
-    const rowsB = [
-      ...db.query(
-        `SELECT response FROM idempotency WHERE scope = '${scopeB}' AND id_key = '${key}'`
-      ),
-    ];
-    expect(rowsB.length).toBe(1);
-    expect(JSON.parse((rowsB[0] as any).response)).toEqual(responseB);
+    expect(recordA.id).not.toBe(recordB.id);
+    expect(recordA.scope).toBe(scopeA);
+    expect(recordB.scope).toBe(scopeB);
+    expect(recordA.responseBody).toBe(responseA);
+    expect(recordB.responseBody).toBe(responseB);
+    await expect(db.getIdempotencyRecord(scopeA, key)).resolves.toEqual(recordA);
+    await expect(db.getIdempotencyRecord(scopeB, key)).resolves.toEqual(recordB);
   });
 });


### PR DESCRIPTION
## Summary of Changes
This pull request adds targeted test coverage for SQLite idempotency scope isolation, fulfilling the requirements outlined in Issue #372.

- **Scope Isolation Verification**: Added a focused test suite in `tests/sqlite-idempotency.test.ts` to ensure that reusing the same client-generated `idempotency_key` across two different scopes (e.g., `sep24:deposit` and `sep31:receive`) does not result in a database collision or cross-contamination.
- **Independent Validation**: Asserts that both canonical records are successfully inserted, maintain separate response payloads, and can be retrieved independently by their respective scopes.

## Testing
- Verified via automated test suite logic.
- Follows all public database adapter method guidelines without introducing new runtime dependencies.

**Closes #372**