### PR TITLE
fix: Trim auth account identifiers and webhook event IDs

### DIFF
--- a/src/runtime/http/express-router-impl.ts
+++ b/src/runtime/http/express-router-impl.ts
@@ -258,7 +258,7 @@ function authenticate(
       token,
       context.config.get('security').interactiveJwtSecret,
     ) as jwt.JwtPayload;
-    const account = typeof decoded.sub === 'string' ? decoded.sub : null;
+    const account = typeof decoded.sub === 'string' ? decoded.sub.trim() : null;
     const scope = typeof decoded.scope === 'string' ? decoded.scope : null;
     const typ = typeof decoded.typ === 'string' ? decoded.typ : null;
     if (
@@ -338,7 +338,8 @@ async function handleAuthChallenge(
     return;
   }
 
-  const account = parseUrl(req).searchParams.get('account');
+  const _accountParam = parseUrl(req).searchParams.get('account');
+  const account = typeof _accountParam === 'string' ? _accountParam.trim() : _accountParam;
   if (!account) {
     sendJson(res, 400, {
       error: 'invalid_request',
@@ -411,7 +412,7 @@ async function handleAuthToken(
     return;
   }
 
-  const account = typeof parsedBody.body.account === 'string' ? parsedBody.body.account : '';
+  const account = typeof parsedBody.body.account === 'string' ? parsedBody.body.account.trim() : '';
   const signedChallenge =
     typeof parsedBody.body.challenge === 'string' ? parsedBody.body.challenge : '';
   if (!account || !signedChallenge) {

--- a/src/runtime/webhooks/default-webhook-processor.ts
+++ b/src/runtime/webhooks/default-webhook-processor.ts
@@ -2,6 +2,11 @@ import type { DatabaseAdapter, WebhookProcessor } from '@/runtime/interfaces.ts'
 import type { AnchorKitConfig } from '@/types/config.ts';
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 
+
+function normalizeEventId(id: string): string {
+  return id.trim();
+}
+
 interface DefaultWebhookProcessorOptions {
   config: AnchorKitConfig;
   database: DatabaseAdapter;
@@ -38,6 +43,8 @@ export class DefaultWebhookProcessor implements WebhookProcessor {
     rawBody: string | Buffer | Uint8Array;
     signature?: string;
   }): Promise<{ duplicate: boolean; eventId: string }> {
+    const eventId = normalizeEventId(input.eventId);
+    input = { ...input, eventId };
     this.verifySignatureIfEnabled(input);
 
     const insertion = await this.database.insertOrGetWebhookEvent({


### PR DESCRIPTION
## Summary

Trim auth account identifiers and webhook event IDs

## Changes

- webhook: trim event IDs; whitespace-only still generates UUID upstream
- express-router-impl.ts: trim auth account identifiers
- example-express-app.test.ts: trim auth account identifiers
- mvp-express.integration.test.ts: trim auth account identifiers
- wrong-secret.test.ts: trim auth account identifiers

Fixes #446
Fixes #462
