### PR TITLE
fix: Validate Stellar address checksums in ValidationUtils

### DIFF
--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -1,4 +1,5 @@
 import type { AnchorKitConfig, Asset, NetworkConfig, SecurityConfig } from '@/types/config.ts';
+import { StrKey } from '@stellar/stellar-sdk';
 import DOMPurify from 'isomorphic-dompurify';
 import type { ServerConfig } from '../types/config.ts';
 
@@ -261,8 +262,9 @@ export const ValidationUtils = {
 
   isValidStellarAddress(address: string): boolean {
     if (!address || typeof address !== 'string') return false;
-    if (!/^G[A-Z2-7]{55}$/.test(address)) return false;
-    return true;
+    // The shape regex alone lets 56-character values with an invalid StrKey
+    // checksum through, so verify the checksum via the Stellar SDK as well.
+    return StrKey.isValidEd25519PublicKey(address);
   },
 
   isValidDatabaseUrl(urlString: string): boolean {

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,5 +1,6 @@
 import { AnchorConfig } from '@/core/config';
 import type { AnchorKitConfig } from '@/types/config';
+import { ValidationUtils } from '@/utils/validation';
 import { describe, expect, it } from 'vitest';
 
 describe('Asset Validation (#254)', () => {
@@ -352,5 +353,26 @@ describe('Operational Website Validation (#388)', () => {
     const anchor = new AnchorConfig(config);
     expect(() => anchor.validate()).toThrow();
     expect(() => anchor.validate()).toThrow(/Invalid email format for operational.supportEmail/);
+  });
+});
+
+describe('Stellar Address Checksum Validation (#386)', () => {
+  const VALID_PUBLIC_KEY = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+  // One-character mutation of the StrKey checksum (final char 5 -> 3)
+  const BAD_CHECKSUM_KEY = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA3';
+
+  it('should return true for a valid public key', () => {
+    expect(ValidationUtils.isValidStellarAddress(VALID_PUBLIC_KEY)).toBe(true);
+  });
+
+  it('should return false for a regex-shaped key with a bad checksum', () => {
+    expect(BAD_CHECKSUM_KEY).toMatch(/^G[A-Z2-7]{55}$/);
+    expect(ValidationUtils.isValidStellarAddress(BAD_CHECKSUM_KEY)).toBe(false);
+  });
+
+  it('should return false for empty or non-string input', () => {
+    expect(ValidationUtils.isValidStellarAddress('')).toBe(false);
+    expect(ValidationUtils.isValidStellarAddress(null as unknown as string)).toBe(false);
+    expect(ValidationUtils.isValidStellarAddress(undefined as unknown as string)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`ValidationUtils.isValidStellarAddress` previously relied on a shape regex
(`/^G[A-Z2-7]{55}$/`), so a 56-character value with an invalid StrKey checksum
could pass validation. Addresses are now verified against the Stellar SDK's
`StrKey.isValidEd25519PublicKey`, which validates the StrKey checksum in
addition to length and charset — catching mistyped account and issuer addresses
before transactions or configuration use them.

## Changes

- `src/utils/validation-helpers.ts`: `isValidStellarAddress` now returns
  `StrKey.isValidEd25519PublicKey(address)` after the existing non-string guard.
  The shape regex was removed since the SDK validator covers it. The helper's
  boolean return contract is unchanged, and no new runtime dependencies were
  added (`@stellar/stellar-sdk` was already a dependency).
- `tests/utils/validation.test.ts`: added a focused `Stellar Address Checksum
  Validation (#386)` block:
  - a known valid public key returns `true`
  - a one-character mutation of the StrKey checksum (final char `5` -> `3`)
    returns `false`, with an assertion that the mutated key still matches the
    old shape regex to confirm the checksum check is what rejects it
  - empty / `null` / `undefined` inputs return `false`

## Testing

- `bun test`: 501 pass, 0 fail (48 files)
- `tsc --noEmit`: clean

Closes #386
