### PR TITLE
Validate auth lifetimes and normalize auth accounts

### DIFF
--- a/src/runtime/http/express-router-impl.ts
+++ b/src/runtime/http/express-router-impl.ts
@@ -215,6 +215,7 @@ function authenticate(
     const decoded = jwt.verify(
       token,
       context.config.get('security').interactiveJwtSecret,
+      { algorithms: ['HS256'] },
     ) as jwt.JwtPayload;
     const account = typeof decoded.sub === 'string' ? decoded.sub : null;
     const scope = typeof decoded.scope === 'string' ? decoded.scope : null;
@@ -287,7 +288,8 @@ async function handleAuthChallenge(
     return;
   }
 
-  const account = parseUrl(req).searchParams.get('account');
+  // Accept canonical Stellar public keys and treat surrounding whitespace as non-semantic.
+  const account = parseUrl(req).searchParams.get('account')?.trim() ?? '';
   if (!account) {
     sendJson(res, 400, {
       error: 'invalid_request',
@@ -359,7 +361,8 @@ async function handleAuthToken(
     return;
   }
 
-  const account = typeof parsedBody.body.account === 'string' ? parsedBody.body.account : '';
+  const account =
+    typeof parsedBody.body.account === 'string' ? parsedBody.body.account.trim() : '';
   const signedChallenge =
     typeof parsedBody.body.challenge === 'string' ? parsedBody.body.challenge : '';
   if (!account || !signedChallenge) {

--- a/src/utils/validation-helpers.ts
+++ b/src/utils/validation-helpers.ts
@@ -17,6 +17,15 @@ function isFinitePositiveNumber(value: unknown): boolean {
   return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
+function isSafePositiveInteger(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    Number.isSafeInteger(value) &&
+    value > 0
+  );
+}
+
 function isValidUrlString(url: string): boolean {
   try {
     const parsed = new URL(url);
@@ -265,19 +274,15 @@ export const SecurityConfigSchema = {
       throw new Error('Missing required secret: security.distributionAccountSecret');
     if (
       config.challengeExpirationSeconds !== undefined &&
-      (typeof config.challengeExpirationSeconds !== 'number' ||
-        !Number.isFinite(config.challengeExpirationSeconds) ||
-        config.challengeExpirationSeconds <= 0)
+      !isSafePositiveInteger(config.challengeExpirationSeconds)
     ) {
-      throw new Error('security.challengeExpirationSeconds must be > 0');
+      throw new Error('security.challengeExpirationSeconds must be a safe positive integer');
     }
     if (
       config.authTokenLifetimeSeconds !== undefined &&
-      (typeof config.authTokenLifetimeSeconds !== 'number' ||
-        !Number.isFinite(config.authTokenLifetimeSeconds) ||
-        config.authTokenLifetimeSeconds <= 0)
+      !isSafePositiveInteger(config.authTokenLifetimeSeconds)
     ) {
-      throw new Error('security.authTokenLifetimeSeconds must be > 0');
+      throw new Error('security.authTokenLifetimeSeconds must be a safe positive integer');
     }
   },
 };

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -243,6 +243,19 @@ describe('AnchorConfig', () => {
       expect(() => config.validate()).not.toThrow();
     });
 
+    it('should accept valid challenge lifetime', () => {
+      const configWithChallengeTtl: AnchorKitConfig = {
+        ...validBaseConfig,
+        security: {
+          ...validBaseConfig.security,
+          challengeExpirationSeconds: 300,
+        },
+      };
+      const config = new AnchorConfig(configWithChallengeTtl);
+      expect(() => config.validate()).not.toThrow();
+      expect(config.get('security').challengeExpirationSeconds).toBe(300);
+    });
+
     it('should accept valid auth token lifetime', () => {
       const configWithTtl: AnchorKitConfig = {
         ...validBaseConfig,
@@ -261,30 +274,30 @@ describe('AnchorConfig', () => {
       expect(config.get('security').authTokenLifetimeSeconds).toBeUndefined();
     });
 
-    it('should reject invalid auth token lifetime (zero)', () => {
+    it.each([
+      ['challengeExpirationSeconds', 0],
+      ['challengeExpirationSeconds', -100],
+      ['challengeExpirationSeconds', 1.5],
+      ['challengeExpirationSeconds', Number.MAX_SAFE_INTEGER + 1],
+      ['challengeExpirationSeconds', Number.NaN],
+      ['challengeExpirationSeconds', Number.POSITIVE_INFINITY],
+      ['authTokenLifetimeSeconds', 0],
+      ['authTokenLifetimeSeconds', -100],
+      ['authTokenLifetimeSeconds', 1.5],
+      ['authTokenLifetimeSeconds', Number.MAX_SAFE_INTEGER + 1],
+      ['authTokenLifetimeSeconds', Number.NaN],
+      ['authTokenLifetimeSeconds', Number.POSITIVE_INFINITY],
+    ])('should reject invalid %s lifetime value %p', (key, value) => {
       const invalidConfig: AnchorKitConfig = {
         ...validBaseConfig,
         security: {
           ...validBaseConfig.security,
-          authTokenLifetimeSeconds: 0,
+          [key]: value,
         },
       };
       const config = new AnchorConfig(invalidConfig);
       expect(() => config.validate()).toThrow(ConfigError);
-      expect(() => config.validate()).toThrow(/authTokenLifetimeSeconds must be > 0/);
-    });
-
-    it('should reject invalid auth token lifetime (negative)', () => {
-      const invalidConfig: AnchorKitConfig = {
-        ...validBaseConfig,
-        security: {
-          ...validBaseConfig.security,
-          authTokenLifetimeSeconds: -100,
-        },
-      };
-      const config = new AnchorConfig(invalidConfig);
-      expect(() => config.validate()).toThrow(ConfigError);
-      expect(() => config.validate()).toThrow(/authTokenLifetimeSeconds must be > 0/);
+      expect(() => config.validate()).toThrow(/must be a safe positive integer/);
     });
   });
 });

--- a/tests/mvp-express.integration.test.ts
+++ b/tests/mvp-express.integration.test.ts
@@ -400,6 +400,17 @@ describe('MVP Express-mounted integration', () => {
     expect(response.body.message).toBe('Query param account is required');
   });
 
+  it('3a) /auth/challenge trims padded account identifiers', async () => {
+    const paddedAccount = `  ${clientKeypair.publicKey()}  `;
+    const response = await invoke({
+      path: `/auth/challenge?account=${encodeURIComponent(paddedAccount)}`,
+      headers: { 'x-forwarded-for': '10.0.0.9' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.challenge).toBeTypeOf('string');
+  });
+
   it('3) challenge -> token happy path', async () => {
     const account = clientKeypair.publicKey();
     const challengeResponse = await invoke({
@@ -516,6 +527,64 @@ describe('MVP Express-mounted integration', () => {
 
     expect(challengeResponse.status).toBe(400);
     expect(challengeResponse.body.error).toBe('invalid_request');
+  });
+
+  it('3b) auth token trims padded account identifiers consistently', async () => {
+    const account = clientKeypair.publicKey();
+    const challengeResponse = await invoke({
+      path: `/auth/challenge?account=${account}`,
+      headers: { 'x-forwarded-for': '10.0.0.7' },
+    });
+
+    expect(challengeResponse.status).toBe(200);
+    const challengeXdr = String(challengeResponse.body.challenge ?? '');
+    const networkPassphrase = String(challengeResponse.body.network_passphrase ?? '');
+    const challengeTx = new Transaction(challengeXdr, networkPassphrase);
+    challengeTx.sign(clientKeypair);
+
+    const tokenResponse = await invoke({
+      method: 'POST',
+      path: '/auth/token',
+      headers: { 'content-type': 'application/json', 'x-forwarded-for': '10.0.0.7' },
+      body: { account: `  ${account}  `, challenge: challengeTx.toXDR() },
+    });
+
+    expect(tokenResponse.status).toBe(200);
+    expect(tokenResponse.body.token).toBeTypeOf('string');
+  });
+
+  it('10f) bearer token signed with RS256 is rejected', async () => {
+    const { generateKeyPairSync } = await import('node:crypto');
+    const jwt = (await import('jsonwebtoken')).default;
+    const { privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const badToken = jwt.sign(
+      {
+        sub: clientKeypair.publicKey(),
+        scope: 'anchor_api',
+        typ: 'access_token',
+      },
+      privateKey,
+      { algorithm: 'RS256', expiresIn: 3600 },
+    );
+
+    const response = await invoke({
+      method: 'POST',
+      path: '/transactions/deposit/interactive',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${badToken}`,
+      },
+      body: { asset_code: 'USDC', amount: '10' },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('unauthorized');
+    expect(response.body.message).toBe('Missing or invalid bearer token');
   });
 
   it('3b) auth token with custom TTL returns correct expires_in', async () => {


### PR DESCRIPTION
Summary
This PR tightens auth configuration validation and normalizes auth account handling to avoid ambiguous or unsafe values during SEP-10 flows.



## How to test?

Please describe how to verify the changes.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests for my changes.
- [x] I have updated the documentation accordingly.
- [x] I have run `bun run test` and `bun run lint` locally.

## Issue Reference

Closes #444
Closes #446
Closes #447
Closes #445
